### PR TITLE
一柳結梨と神庭生徒会防衛隊のリリィの情報を追加

### DIFF
--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -251,7 +251,8 @@
         <Tanaka_Ichi>,
         <Egawa_Kusumi>,
         <Ando_Tazusa>,
-        <Kawanabe_Nazuna> ;
+        <Kawanabe_Nazuna>,
+        <Shiozaki_Suzume> ;
     a lily:Charm ;
 .
 
@@ -526,7 +527,8 @@
         <Tiuccia_Paumgartner>,
         <Fujita_Asagao>,
         <Tachihara_Sayu>,
-        <Takasuga_Tsukushi> ;
+        <Takasuga_Tsukushi>,
+        <Ishizuka_Fujino> ;
     a lily:Charm ;
 .
 

--- a/RDFs/lily_kamba.ttl
+++ b/RDFs/lily_kamba.ttl
@@ -472,16 +472,18 @@
     foaf:age "16"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--02-25"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "O"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
-    # lily:favorite ""@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:favorite
+        "美術館巡り"@ja,
+        "フクロモモンガ"@ja ;
+    lily:notGood "不潔なもの"@ja ;
+    lily:hobby_talent "DIY"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
     lily:rareSkill "ヘリオスフィア"^^xsd:string ;
     lily:subSkill "軍神の加護"^^xsd:string ;
@@ -538,15 +540,18 @@
     foaf:age "15"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--03-26"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
     lily:bloodType "AB"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
-    lily:favorite "抹茶"@ja ;
-    # lily:notGood ""@ja ;
+    lily:favorite
+        "抹茶"@ja,
+        "パーティやお茶会"@ja,
+        "ボルダリング" @ja ;
+    lily:notGood "地図を読むこと"@ja ;
     lily:hobby_talent
         "和楽器の演奏"@ja,
         "茶の湯"@ja ;
@@ -608,26 +613,28 @@
     foaf:age "15"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--06-13"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "O"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
-    # lily:favorite ""@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:favorite "鉱物収集"@ja ;
+    lily:notGood "注射"@ja ;
+    lily:hobby_talent
+        "絵を描くこと"@ja,
+        "博物学"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
-    # lily:rareSkill ""^^xsd:string ;
+    lily:rareSkill "ルナティックトランサー"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted false ;
     # lily:boostedSkill ""^^xsd:string ;
-    # lily:charm [
-    #    lily:resource <> ;
-    #    lily:usedIn ""^^xsd:string ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:charm [
+        lily:resource <Brionac> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     lily:garden "神庭女子藝術高校"^^xsd:string ;
     # lily:gardenDepartment ""^^xsd:string ;
     lily:grade "10"^^xsd:integer ;
@@ -674,26 +681,28 @@
     foaf:age "16"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--11-21"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "AB"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
-    # lily:favorite ""@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:favorite
+        "美しいもの"@ja,
+        "人文学"@ja ;
+    lily:notGood "寒さ"@ja ;
+    lily:hobby_talent "絵画（日本画）"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
     lily:rareSkill "円環の御手"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted false ;
     # lily:boostedSkill ""^^xsd:string ;
-    # lily:charm [
-    #    lily:resource <> ;
-    #    lily:usedIn ""^^xsd:string ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:charm [
+        lily:resource <Chrysaor> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     lily:garden "神庭女子藝術高校"^^xsd:string ;
     # lily:gardenDepartment ""^^xsd:string ;
     lily:grade "11"^^xsd:integer ;

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -954,9 +954,9 @@
     schema:gender "female"^^xsd:string ;
     lily:color "F0B6FF"^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
-    # lily:favorite ""@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:favorite "スコーン"@ja ;
+    lily:notGood "なし"@ja ;
+    lily:hobby_talent "匂いで相手の気持ちがわかる"@ja ;
     lily:skillerVal "50"^^xsd:integer ;
     # lily:rareSkill ""^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
@@ -964,7 +964,9 @@
     # lily:boostedSkill ""^^xsd:string ;
     lily:charm [
         lily:resource <Gungnir> ;
-        lily:usedIn "アニメ"^^xsd:string ;
+        lily:usedIn
+            "アニメ"^^xsd:string,
+            "ラスバレ"^^xsd:string ;
         # lily:additionalInformation ""@ja ;
     ] ;
     lily:garden "私立百合ヶ丘女学院"^^xsd:string ;
@@ -997,7 +999,9 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q16264202>,
             <http://ja.dbpedia.org/resource/伊藤美来> ;
-        lily:performIn <Assault_Lily_Bouquet> ;
+        lily:performIn
+            <Assault_Lily_Bouquet>,
+            <Assault_Lily_Last_Bullet> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;


### PR DESCRIPTION
### 概要

一柳結梨と神庭生徒会防衛隊のリリィの情報を追加

### 情報源

ラスバレのキャラプロフィールから
スクリーンショット：https://twitter.com/nagisan_2nd/status/1642660010051383296

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

CHARMですが、ラスバレでは武器ステータス（攻撃力など）の違いで名前が変わるので専用機ではないです。

これからラスバレでの情報を追加していきたいと思うのですが、良いですか？
