### PR TITLE
楽曲情報の追加

### DIFF
--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -389,7 +389,7 @@
     ] ;
     lily:cast [
         schema:name "野中深愛"@ja ;
-        lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
+        lily:resource <https://ja.dbpedia.org/resource/野中深愛> ;
         lily:performIn
             <The_Fateful_Gift>,
             <Assault_Lily_Last_Bullet>,

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -389,7 +389,7 @@
     ] ;
     lily:cast [
         schema:name "野中深愛"@ja ;
-        # lily:resource <> ;
+        lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
         lily:performIn
             <The_Fateful_Gift>,
             <Assault_Lily_Last_Bullet>,

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -5632,7 +5632,7 @@
     lily:composer "TAKUYA KIYOHARA"@ja ;
     lily:arranger "gaze//he's me"@ja ;
     # lily:additionalInformation ""@ja ;
-    schema:duration "3M55S"^^xsd:duration ;
+    schema:duration "PT3M55S"^^xsd:duration ;
     schema:inAlbum <Cherish> ;
     lily:singer [
         schema:name "白井夢結（CV：夏吉ゆうこ）"@ja ;
@@ -5770,7 +5770,7 @@
     schema:duration "PT4M6S"^^xsd:duration ;
     schema:inAlbum <Diverse> ;
     lily:singer [
-        schema:name "飯島恋花（CV：石飛恵里花）"
+        schema:name "飯島恋花（CV：石飛恵里花）"@ja ;
         lily:cast [
             schema:name "石飛恵里花"@ja ;
             lily:resource <https://www.wikidata.org/wiki/Q51166206> ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -586,7 +586,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            # lily:resource  ;
+            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;
@@ -5014,7 +5014,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            # lily:resource  ;
+            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ], [
@@ -5155,7 +5155,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            # lily:resource  ;
+            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;
@@ -5338,7 +5338,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            # lily:resource  ;
+            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;
@@ -5817,7 +5817,7 @@
         schema:name "芹沢千香瑠（CV：野中深愛）"@ja ;
         lily:cast [
             schema:name "野中深愛"@ja ;
-            # lily:resource  ;
+            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -4551,7 +4551,7 @@
     schema:duration "PT4M52S"^^xsd:duration ;
     lily:singer [
         schema:name "白井夢結＆吉村・Thi・梅（CV：夏吉ゆうこ＆岩田陽葵）"@ja ;
-        lily:cast [ 
+        lily:cast [
             schema:name "夏吉ゆうこ"@ja ;
             lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
             lily:performAs <Shirai_Yuyu> ;
@@ -5658,7 +5658,7 @@
     schema:inAlbum <Cherish> ;
     lily:singer [
         schema:name "一柳梨璃（CV：赤尾ひかる）"@ja ;
-        lily:cast 
+        lily:cast
             [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -24,7 +24,7 @@
         lily:song <Song_Tsunagari> ;
     ], [
         lily:listOrder "3"^^xsd:integer ;
-        lily:song <Song_Taisetsu_Wo_Oshieyou> ;
+        lily:song <Song_Taisetsu_Wo_Kazoeyou> ;
     ] ;
     a lily:MusicAlbum ;
 .
@@ -167,7 +167,7 @@
     a lily:Music ;
 .
 
-<Song_Taisetsu_Wo_Oshieyou>
+<Song_Taisetsu_Wo_Kazoeyou>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "大切を数えよう"@ja ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -5538,7 +5538,7 @@
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "マッシブ！"@ja ;
-    lily:lyricist " 安藤紗々"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
     lily:composer "神田ジョン"@ja ;
     lily:arranger "神田ジョン"@ja ;
     # lily:additionalInformation ""@ja ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -38,7 +38,9 @@
     lily:arranger "秋月須清"@ja ;
     lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」エンディングテーマ"@ja ;
     schema:duration "PT4M37S"^^xsd:duration ;
-    schema:inAlbum <Edel_Lilie> ;
+    schema:inAlbum
+        <Edel_Lilie>,
+        <Cherish> ;
     lily:singer [
         schema:name "一柳隊"@ja ;
         lily:cast [
@@ -4110,5 +4112,1911 @@
     # lily:additionalInformation ""@ja ;
     schema:duration "PT3M51S"^^xsd:duration ;
     schema:inAlbum <Odaiba_Jogakkou_Stage_Song_Selection> ;
+    a lily:Music ;
+.
+
+<Heart_Heart>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Heart+Heart"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2020-10-31"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT4M"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Heart_Heart> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Heart_Heart>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Heart+Heart"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第5話エンディングテーマ"@ja ;
+    schema:duration "PT4M28S"^^xsd:duration ;
+    schema:inAlbum <Heart_Heart> ;
+    lily:singer [
+        schema:name "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<GROWING>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "GROWING*"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳隊"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2020-11-28"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT4M40S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_GROWING> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_GROWING>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "GROWING*"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "俊龍"@ja ;
+    lily:arranger "大和"@ja ;
+    lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第8話エンディングテーマ"@ja ;
+    schema:duration "PT4M40S"^^xsd:duration ;
+    schema:inAlbum <GROWING> ;
+    lily:singer [
+        schema:name "一柳隊"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Mabataki>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "まばたき"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳結梨（CV：伊藤美来）"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2020-12-05"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT4M"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Mabataki> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Mabataki>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "まばたき"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "大和"@ja ;
+    lily:arranger "大和"@ja ;
+    lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第9話エンディングテーマ"@ja ;
+    schema:duration "PT4M"^^xsd:duration ;
+    schema:inAlbum <Mabataki> ;
+    lily:singer [
+        schema:name "一柳結梨（CV：伊藤美来）"@ja ;
+        lily:cast [
+            schema:name "伊藤美来"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264202>,
+                <http://ja.dbpedia.org/resource/伊藤美来> ;
+            lily:performAs <Hitotsuyanagi_Yuri> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<Kimino_Tewo_Hanasanai>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "君の手を離さない"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳隊＆ルド女選抜＆御台場選抜＆相模女子選抜＆ヘルヴォル＆御前"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2020-12-26"^^xsd:date ;
+    schema:numTracks "2"^^xsd:integer ;
+    schema:timeRequired "PT10M36S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Kimino_Tewo_Hanasanai> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Kimino_Tewo_Hanasanai_Bouquet_Ver>
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Kimino_Tewo_Hanasanai>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "君の手を離さない"@ja ;
+    lily:lyricist "谷ナオキ"@ja ;
+    lily:composer "谷ナオキ"@ja ;
+    lily:arranger "谷ナオキ"@ja ;
+    lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第12話挿入歌、舞台「アサルトリリィ The Fateful Gift」主題歌"@ja ;
+    schema:duration "PT5M18S"^^xsd:duration ;
+    schema:inAlbum <Kimino_Tewo_Hanasanai> ;
+    lily:singer [
+        schema:name "一柳隊＆ルド女選抜＆御台場選抜＆相模女子選抜＆ヘルヴォル＆御前"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "田上真里奈"@ja;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q17161003>,
+                <http://ja.dbpedia.org/resource/田上真里奈> ;
+            lily:performAs <Toda_Kotohi> ;
+            lily:additionalInformation "「戸田・エウラリア・琴陽」役"@ja ;
+        ], [
+            schema:name "中村裕香里"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q60613344> ;
+            lily:performAs <Fukuyama_Jeanne_Sachie> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "宮瀬玲奈"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q56556209> ;
+            lily:performAs <Kishimoto_Lucia_Raimu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "梅原サエリ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q74146771> ;
+            lily:performAs <Kuroki_Francisca_Yuria> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "長橋有沙"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q29526415> ;
+            lily:performAs <Hasegawa_Gabriela_Tsugumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "あわつまい"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q56253675> ;
+            lily:performAs <Kawamura_Yuzuriha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西葉瑞希"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q98734254>,
+                <http://ja.dbpedia.org/resource/西葉瑞希> ;
+            lily:performAs <Funada_Ui> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "石井陽菜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q18817351>,
+                <http://ja.dbpedia.org/resource/石井陽菜> ;
+            lily:performAs <Funada_Kiito> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "富田麻帆"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q9026977>,
+                <http://ja.dbpedia.org/resource/富田麻帆> ;
+            lily:performAs <Shiba_Tomoshibi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "広沢麻衣"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q34856960> ;
+            lily:performAs <Ishikawa_Aoi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "藤井彩加"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q28068428> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏目愛海"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q47582342> ;
+            lily:performAs <Sasaki_Ran> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "石飛恵里花"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q51166206> ;
+            lily:performAs <Iijima_Renka> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "三村遙佳"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q97590111> ;
+            lily:performAs <Hatsukano_Yo> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "野中深愛"@ja ;
+            lily:resource  <https://ja.dbpedia.org/page/野中深愛>;
+            lily:performAs <Serizawa_Chikaru> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "佃井皆美"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q11381598>,
+                <http://ja.dbpedia.org/resource/佃井皆美> ;
+            lily:performAs <Gozen> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Kimino_Tewo_Hanasanai_Bouquet_Ver>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "君の手を離さない ～BOUQUET Ver.～"@ja ;
+    lily:lyricist "谷ナオキ"@ja ;
+    lily:composer "谷ナオキ"@ja ;
+    lily:arranger "谷ナオキ"@ja ;
+    lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第12話挿入歌"@ja ;
+    schema:duration "PT5M18S"^^xsd:duration ;
+    schema:inAlbum <Kimino_Tewo_Hanasanai> ;
+    lily:singer [
+        schema:name "一柳隊"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+
+<Song_Rainbow>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Rainbow"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "結城アイラ"@ja ;
+    # lily:arranger ""@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M52S"^^xsd:duration ;
+    lily:singer [
+        schema:name "白井夢結＆吉村・Thi・梅（CV：夏吉ゆうこ＆岩田陽葵）"@ja ;
+        lily:cast [ 
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Tsukiakarino_Contrast>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "つきあかりのコントラスト"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "大和"@ja ;
+    # lily:arranger ""@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M59S"^^xsd:duration ;
+    lily:singer [
+        schema:name "一柳梨璃＆安藤鶴紗（CV：赤尾ひかる＆紡木吏佐）"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Itsudemo_Sobade>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "いつでもそばで。"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "谷ナオキ"@ja ;
+    # lily:arranger ""@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M50S"^^xsd:duration ;
+    lily:singer [
+        schema:name "郭神琳＆王雨嘉（CV：星守紗凪＆遠野ひかる）"@ja ;
+        lily:cast [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Lily_Lily_GoGo_Lily>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "リリィ♡リリィ♡GOGOリリィ♡"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "斉藤信治"@ja ;
+    lily:arranger "大久保薫"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M16S"^^xsd:duration ;
+    lily:singer [
+        schema:name "楓・J・ヌーベル＆二川二水＆ミリアム・ヒルデガルド・v・グロピウス（CV：井澤美香子＆西本りみ＆高橋花林）"@ja ;
+        lily:cast [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<Neunt_Praeludium>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Neunt Praeludium"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳隊"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2022-01-20"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT4M29S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Neunt_Praeludium>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Neunt Praeludium"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "俊龍"@ja ;
+    lily:arranger "松田彬人"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M29S"^^xsd:duration ;
+    schema:inAlbum
+        <Neunt_Praeludium>,
+        <Cherish> ;
+    lily:singer [
+        schema:name "一柳隊"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Neunt_Praeludium_Last_Bullet_Mix_Blu_Ray_Limited_Addition>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Neunt Praeludium(Last Bullet MIX)"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "アサルトリリィ Last Bullet"@ja ;
+    lily:edition "Blu-ray付生産限定盤"@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "シングル"@ja ;
+    schema:datePublished "2022-02-09"^^xsd:date ;
+    schema:numTracks "4"^^xsd:integer ;
+    schema:timeRequired "PT17M24S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki> ;
+    ], [
+        lily:listOrder "3"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
+    ], [
+        lily:listOrder "4"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Neunt_Praeludium_Last_Bullet_Mix_Normal_A>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Neunt Praeludium(Last Bullet MIX)"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "アサルトリリィ Last Bullet"@ja ;
+    lily:edition "通常盤A(一柳隊ver.)"@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "シングル"@ja ;
+    schema:datePublished "2022-02-09"^^xsd:date ;
+    schema:numTracks "6"^^xsd:integer ;
+    schema:timeRequired "PT28M40S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki_Hitotuyanagitai_Version> ;
+    ], [
+        lily:listOrder "3"^^xsd:integer ;
+        lily:song <Song_Omoidega_Afureteru> ;
+    ], [
+        lily:listOrder "4"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
+    ], [
+        lily:listOrder "5"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+    ], [
+        lily:listOrder "6"^^xsd:integer ;
+        lily:song <Song_Omoidega_Afureteru_Instrumental> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Neunt_Praeludium_Last_Bullet_Mix_Normal_B>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Neunt Praeludium(Last Bullet MIX)"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "アサルトリリィ Last Bullet"@ja ;
+    lily:edition "通常盤B(ヘルヴォルver.)"@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "シングル"@ja ;
+    schema:datePublished "2022-02-09"^^xsd:date ;
+    schema:numTracks "6"^^xsd:integer ;
+    schema:timeRequired "PT25M34S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki_Hervor_Version> ;
+    ], [
+        lily:listOrder "3"^^xsd:integer ;
+        lily:song <Song_Resonant_Hearts> ;
+    ], [
+        lily:listOrder "4"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
+    ], [
+        lily:listOrder "5"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+    ], [
+        lily:listOrder "6"^^xsd:integer ;
+        lily:song <Song_Resonant_Hearts_Instrumental> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Neunt_Praeludium_Last_Bullet_Mix_Normal_C>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Neunt Praeludium(Last Bullet MIX)"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "アサルトリリィ Last Bullet"@ja ;
+    lily:edition "通常盤C(グラン・エプレver.)"@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "シングル"@ja ;
+    schema:datePublished "2022-02-09"^^xsd:date ;
+    schema:numTracks "6"^^xsd:integer ;
+    schema:timeRequired "PT25M51S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki_Gran_Eple_Version> ;
+    ], [
+        lily:listOrder "3"^^xsd:integer ;
+        lily:song <Song_Treasure_Every_Day> ;
+    ], [
+        lily:listOrder "4"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
+    ], [
+        lily:listOrder "5"^^xsd:integer ;
+        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+    ], [
+        lily:listOrder "6"^^xsd:integer ;
+        lily:song <Song_Treasure_Every_Day_Instrumental> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Neunt_Praeludium_Last_Bullet_Mix>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Neunt Praeludium(Last Bullet MIX)"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "俊龍"@ja ;
+    lily:arranger "XELIK"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M11S"^^xsd:duration ;
+    schema:inAlbum
+        <Neunt_Praeludium_Last_Bullet_Mix_Blu_Ray_Limited_Addition>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_A>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_B>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_C> ;
+    lily:singer [
+        schema:name "一柳梨璃＆白井夢結＆相澤一葉＆今叶星（CV：赤尾ひかる＆夏吉ゆうこ＆藤井彩加＆前田佳織里）"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "藤井彩加"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q28068428> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "前田佳織里"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q41693141> ;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    lily:composer "俊龍"@ja ;
+    # lily:additionalInformation ""@ja;
+    schema:duration "PT4M12S"^^xsd:duration ;
+    schema:inAlbum
+        <Neunt_Praeludium_Last_Bullet_Mix_Blu_Ray_Limited_Addition>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_A>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_B>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_C> ;
+    a lily:Music ;
+.
+
+<Song_Tsubomino_Nakano_Kiseki>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "蕾の中の奇跡"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M32S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Blu_Ray_Limited_Addition> ;
+    lily:singer [
+        schema:name "アサルトリリィ Last Bullet"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "藤井彩加"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q28068428> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏目愛海"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q47582342> ;
+            lily:performAs <Sasaki_Ran> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "石飛恵里花"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q51166206> ;
+            lily:performAs <Iijima_Renka> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "三村遙佳"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q97590111> ;
+            lily:performAs <Hatsukano_Yo> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "野中深愛"@ja ;
+            # lily:resource  ;
+            lily:performAs <Serizawa_Chikaru> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "前田佳織里"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q41693141> ;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "礒部花凜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q18990383>,
+                <http://ja.dbpedia.org/resource/礒部花凜> ;
+            lily:performAs <Miyagawa_Takane> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "東城咲耶子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041619>,
+                <http://ja.dbpedia.org/resource/東城咲耶子> ;
+            lily:performAs <Toki_Kureha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "進藤あまね"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q60989810> ;
+            lily:performAs <Tamba_Akari> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "富田美憂"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q22131362>,
+                <http://ja.dbpedia.org/resource/富田美憂> ;
+            lily:performAs <Sadamori_Himeka> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Tsubomino_Nakano_Kiseki_Hitotuyanagitai_Version>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "蕾の中の奇跡"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M32S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_A> ;
+    lily:singer [
+        schema:name "一柳隊"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Tsubomino_Nakano_Kiseki_Hervor_Version>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "蕾の中の奇跡"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M32S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_B> ;
+    lily:singer [
+        schema:name "ヘルヴォル"@ja ;
+        lily:cast [
+            schema:name "藤井彩加"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q28068428> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏目愛海"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q47582342> ;
+            lily:performAs <Sasaki_Ran> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "石飛恵里花"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q51166206> ;
+            lily:performAs <Iijima_Renka> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "三村遙佳"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q97590111> ;
+            lily:performAs <Hatsukano_Yo> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "野中深愛"@ja ;
+            # lily:resource  ;
+            lily:performAs <Serizawa_Chikaru> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Tsubomino_Nakano_Kiseki_Gran_Eple_Version>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "蕾の中の奇跡"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M32S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_C> ;
+    lily:singer [
+        schema:name "グラン・エプレ"@ja ;
+        lily:cast [
+            schema:name "前田佳織里"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q41693141> ;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "礒部花凜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q18990383>,
+                <http://ja.dbpedia.org/resource/礒部花凜> ;
+            lily:performAs <Miyagawa_Takane> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "東城咲耶子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041619>,
+                <http://ja.dbpedia.org/resource/東城咲耶子> ;
+            lily:performAs <Toki_Kureha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "進藤あまね"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q60989810> ;
+            lily:performAs <Tamba_Akari> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "富田美憂"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q22131362>,
+                <http://ja.dbpedia.org/resource/富田美憂> ;
+            lily:performAs <Sadamori_Himeka> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Tsubomino_Nakano_Kiseki_Instrumental>
+    lily:genre "歌"@ja ;
+    lily:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "蕾の中の奇跡 -instrumental-"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    schema:duration "PT4M32S"^^xsd:duration ;
+    schema:inAlbum
+        <Neunt_Praeludium_Last_Bullet_Mix_Blu_Ray_Limited_Addition>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_A>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_B>,
+        <Neunt_Praeludium_Last_Bullet_Mix_Normal_C> ;
+    a lily:Music ;
+.
+
+<Song_Omoidega_Afureteru>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "思い出が溢れてる"@ja ;
+    lily:lyricist "谷ナオキ"@ja ;
+    lily:composer "谷ナオキ"@ja ;
+    # lily:arranger ""@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT5M39S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_A> ;
+    lily:singer [
+        schema:name "一柳隊"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Omoidega_Afureteru_Instrumental>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "想い出が溢れてる -instrumental-"@ja ;
+    lily:composer "谷ナオキ"@ja ;
+    # lily:addtionalInformation ""@ja ;
+    schema:duration "PT5M39S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_A> ;
+    a lily:Music;
+.
+
+<Song_Resonant_Hearts>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Resonant Hearts"@ja ;
+    lily:lyricist "吾龍" ;
+    lily:composer "タカハシヒビキ"@ja ;
+    # lily:arranger ""@ja ;
+    # lily:additionalInformation "" @ja ;
+    schema:duration "PT4M7S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_B> ;
+    lily:singer [
+        schema:name "ヘルヴォル"@ja ;
+        lily:cast [
+            schema:name "藤井彩加"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q28068428> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏目愛海"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q47582342> ;
+            lily:performAs <Sasaki_Ran> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "石飛恵里花"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q51166206> ;
+            lily:performAs <Iijima_Renka> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "三村遙佳"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q97590111> ;
+            lily:performAs <Hatsukano_Yo> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "野中深愛"@ja ;
+            # lily:resource  ;
+            lily:performAs <Serizawa_Chikaru> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Resonant_Hearts_Instrumental>
+    lily:genre "歌"@ja ;
+    schema:language "ja-JP"^^xsd:language ;
+    schema:name "Resonant Hearts -instrumental-"@ja ;
+    lily:composer "タカハシヒビキ"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M7S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_B> ;
+    a lily:Music ;
+.
+
+<Song_Treasure_Every_Day>
+    lily:genre "歌"@ja ;
+    schema:language "ja-JP"^^xsd:language ;
+    schema:name "Treasure Every Day!"@ja ;
+    lily:lyricist "結城アイラ"@ja ;
+    lily:composer "俊龍"@ja ;
+    lily:arranger "俊龍"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M15S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_C> ;
+    lily:singer [
+        schema:name "グラン・エプレ"@ja ;
+        lily:cast [
+            schema:name "前田佳織里"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q41693141> ;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "礒部花凜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q18990383>,
+                <http://ja.dbpedia.org/resource/礒部花凜> ;
+            lily:performAs <Miyagawa_Takane> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "東城咲耶子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041619>,
+                <http://ja.dbpedia.org/resource/東城咲耶子> ;
+            lily:performAs <Toki_Kureha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "進藤あまね"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q60989810> ;
+            lily:performAs <Tamba_Akari> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "富田美憂"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q22131362>,
+                <http://ja.dbpedia.org/resource/富田美憂> ;
+            lily:performAs <Sadamori_Himeka> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Treasure_Every_Day_Instrumental>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    lily:composer "俊龍"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M15S"^^xsd:duration ;
+    schema:inAlbum <Neunt_Praeludium_Last_Bullet_Mix_Normal_C> ;
+    a lily:Music ;
+.
+
+<Cherish>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Cherish"@ja ;
+    lily:additionalInformation "一柳隊のソロ曲のアルバム"@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳隊"@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "アルバム"@ja ;
+    # lily:edition ""@ja ;
+    schema:datePublished "2022-08-03"^^xsd:date ;
+    schema:numTracks "11"^^xsd:integer ;
+    schema:timeRequired "PT44M38S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Neunt_Praeludium> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Veins_Of_FLOWER> ;
+    ], [
+        lily:listOrder "3"^^xsd:integer ;
+        lily:song <Song_Paralyzer> ;
+    ], [
+        lily:listOrder "4"^^xsd:integer ;
+        lily:song <Song_La_Vie_En_Rose> ;
+    ], [
+        lily:listOrder "5"^^xsd:integer ;
+        lily:song <Song_Massive> ;
+    ], [
+        lily:listOrder "6"^^xsd:integer ;
+        lily:song <Song_Pinky_Promise> ;
+    ], [
+        lily:listOrder "7"^^xsd:integer ;
+        lily:song <Song_Pretty_Please> ;
+    ], [
+        lily:listOrder "8"^^xsd:integer ;
+        lily:song <Song_Everlasting> ;
+    ], [
+        lily:listOrder "9"^^xsd:integer ;
+        lily:song <Song_Unmeino_Filament> ;
+    ], [
+        lily:listOrder "10"^^xsd:integer ;
+        lily:song <Song_Cherish> ;
+    ], [
+        lily:listOrder "11"^^xsd:integer ;
+        lily:song <Song_Edel_Lilie> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Veins_Of_FLOWER>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Veins of FLOWER"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "KHAi"@ja ;
+    lily:arranger "大和"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M55S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "吉村・Thi・梅（CV：岩田陽葵）"@ja ;
+        lily:cast [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Paralyzer>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "パラライザ"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "大和"@ja ;
+    lily:arranger "大和"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M18S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "安藤鶴紗（CV：紡木吏佐）"@ja ;
+        lily:cast [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_La_Vie_En_Rose>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "La Vie en rose 〜楓・J・ヌーベルの優雅な日常〜"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "伊藤翼"@ja ;
+    lily:arranger "伊藤翼"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M16S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "楓・J・ヌーベル（CV：井澤美香子）"@ja ;
+        lily:cast [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Massive>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "マッシブ！"@ja ;
+    lily:lyricist " 安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M22S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "二川二水（CV：西本りみ）"@ja ;
+        lily:cast [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Pinky_Promise>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "ピンキー・プロミス"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "gen"@ja ;
+    lily:arranger "gen"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M31S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "ミリアム・ヒルデガルド・ｖ・グロピウス（CV：高橋花林）"@ja ;
+        lily:cast [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Pretty_Please>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Pretty Please"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "yuigot"@ja ;
+    lily:arranger "yuigot"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M55S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "王雨嘉 （CV：遠野ひかる）"@ja ;
+        lily:cast [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Everlasting>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Everlasting"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "LiCu"@ja ;
+    lily:arranger "LiCu"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M10S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "郭神琳（CV：星守紗凪）"@ja ;
+        lily:cast [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Unmeino_Filament>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "運命のFilament"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "TAKUYA KIYOHARA"@ja ;
+    lily:arranger "gaze//he's me"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "3M55S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "白井夢結（CV：夏吉ゆうこ）"@ja ;
+        lily:cast [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Cherish>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "チェリッシュ♡"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "俊龍"@ja ;
+    lily:arranger "松田彬人"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT5M11S"^^xsd:duration ;
+    schema:inAlbum <Cherish> ;
+    lily:singer [
+        schema:name "一柳梨璃（CV：赤尾ひかる）"@ja ;
+        lily:cast 
+            [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Diverse>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Diverse"@ja ;
+    lily:additionalInformation "ヘルヴォル、グラン・エプレのソロ曲のアルバム"@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "ヘルヴォル、グラン・エプレ"@ja ;
+    lily:recordLabel "ブシロードミュージック"@ja ;
+    lily:format "アルバム"@ja ;
+    # lily:edition ""@ja ;
+    schema:datePublished "2022-08-03"^^xsd:date ;
+    schema:numTracks "10"^^xsd:integer ;
+    schema:timeRequired "PT40M12S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Vertical_Line> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Hidamari> ;
+    ], [
+        lily:listOrder "3"^^xsd:integer ;
+        lily:song <Song_Gonna_Be_OK> ;
+    ], [
+        lily:listOrder "4"^^xsd:integer ;
+        lily:song <Song_Good_Bye_My_Rainy_Days> ;
+    ], [
+        lily:listOrder "5"^^xsd:integer ;
+        lily:song <Song_Hope> ;
+    ], [
+        lily:listOrder "6"^^xsd:integer ;
+        lily:song <Song_Maka_Fushigiwo_Daisukida> ;
+    ], [
+        lily:listOrder "7"^^xsd:integer ;
+        lily:song <Song_Preserved_Idol> ;
+    ], [
+        lily:listOrder "8"^^xsd:integer ;
+        lily:song <Song_Oh_Precious> ;
+    ], [
+        lily:listOrder "9"^^xsd:integer ;
+        lily:song <Song_Dearest_Dream> ;
+    ], [
+        lily:listOrder "10"^^xsd:integer ;
+        lily:song <Song_Dears_And_Tears> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Vertical_Line>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Vertical Line"@ja ;
+    lily:lyricist "吾龍"@ja ;
+    lily:composer "大和"@ja ;
+    lily:arranger "大和"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M4S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "相澤一葉（CV：藤井彩加）"@ja ;
+        lily:cast [
+            schema:name "藤井彩加"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q28068428> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Hidamari>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "ひだまり"@ja ;
+    lily:lyricist "吾龍"@ja ;
+    lily:composer "島みやえい子"@ja ;
+    lily:arranger "下村佳代"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M39S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "佐々木藍 （CV：夏目愛海）"@ja ;
+        lily:cast [
+            schema:name "夏目愛海"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q47582342> ;
+            lily:performAs <Sasaki_Ran> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Gonna_Be_OK>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Gonna be OK!"@ja ;
+    lily:lyricist "吾龍"@ja ;
+    lily:composer "XELIK"@ja ;
+    lily:arranger "XELIK"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M6S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "飯島恋花（CV：石飛恵里花）"
+        lily:cast [
+            schema:name "石飛恵里花"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q51166206> ;
+            lily:performAs <Iijima_Renka> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Good_Bye_My_Rainy_Days>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Good-bye My Rainy Days"@ja ;
+    lily:lyricist "吾龍"@ja ;
+    lily:composer "中居廉"@ja ;
+    lily:arranger "tepe"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M1S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "初鹿野瑤（CV：三村遙佳）"@ja ;
+        lily:cast [
+            schema:name "三村遙佳"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q97590111> ;
+            lily:performAs <Hatsukano_Yo> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music;
+.
+
+<Song_Hope>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "hope"@ja ;
+    lily:lyricist "吾龍"@ja ;
+    lily:composer "gaze//he's me"@ja ;
+    lily:arranger "gaze//he's me"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT3M32S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "芹沢千香瑠（CV：野中深愛）"@ja ;
+        lily:cast [
+            schema:name "野中深愛"@ja ;
+            # lily:resource  ;
+            lily:performAs <Serizawa_Chikaru> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Maka_Fushigiwo_Daisukida>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "摩訶不思議をダイスキダ"@ja ;
+    lily:lyricist "結城アイラ"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M17S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "丹羽灯莉（CV：進藤あまね）"@ja ;
+        lily:cast [
+            schema:name "進藤あまね"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q60989810> ;
+            lily:performAs <Tamba_Akari> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Preserved_Idol>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "プリザーブド☆アイドル"@ja ;
+    lily:lyricist "結城アイラ"@ja ;
+    lily:composer "俊龍"@ja ;
+    lily:arranger "yuigot"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M10S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "定盛姫歌（CV：富田美憂）"@ja ;
+        lily:cast [
+            schema:name "富田美憂"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q22131362>,
+                <http://ja.dbpedia.org/resource/富田美憂> ;
+            lily:performAs <Sadamori_Himeka> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Oh_Precious>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Oh!Precious!"@ja ;
+    lily:lyricist "結城アイラ"@ja ;
+    lily:composer "伊藤翼"@ja ;
+    lily:arranger "伊藤翼"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M21S"@ja ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "土岐紅巴（CV：東城咲耶子）"@ja ;
+        lily:cast [
+            schema:name "東城咲耶子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041619>,
+                <http://ja.dbpedia.org/resource/東城咲耶子> ;
+            lily:performAs <Toki_Kureha> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Dearest_Dream>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Dearest Dream"@ja ;
+    lily:lyricist "結城アイラ"@ja ;
+    lily:composer "結城アイラ"@ja ;
+    lily:arranger "大和"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M2S"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "宮川高嶺（CV：礒部花凜）"@ja ;
+        lily:cast [
+            schema:name "礒部花凜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q18990383>,
+                <http://ja.dbpedia.org/resource/礒部花凜> ;
+            lily:performAs <Miyagawa_Takane> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Dears_And_Tears>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Dears&Tears"@ja ;
+    lily:lyricist "結城アイラ"@ja ;
+    lily:composer "小野寺祐輔"@ja ;
+    lily:arranger "小野寺祐輔"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M"^^xsd:duration ;
+    schema:inAlbum <Diverse> ;
+    lily:singer [
+        schema:name "今叶星（CV：前田佳織里）"@ja ;
+        lily:cast [
+            schema:name "前田佳織里"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q41693141> ;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Overcast_Sky>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Overcast Sky"@ja ;
+    lily:lyricist "結城アイラ"@ja ;
+    lily:composer "Islet"@ja ;
+    lily:arranger "Islet"@ja ;
+    lily:additionalInformation "アサルトリリィ Last Bullet メインストーリー 新章グラン・エプレ編のテーマソング"@ja ;
+    schema:duration "PT3M42S"^^xsd:duration ;
+    # schema:inAlbum <> ;
+    lily:singer [
+        schema:name "新生グラン・エプレ"@ja ;
+        lily:cast [
+            schema:name "前田佳織里"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q41693141>,
+                <https://ja.dbpedia.org/page/前田佳織里>;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "磯部花凜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q18990383>,
+                <https://ja.dbpedia.org/resource/礒部花凜> ;
+            lily:performAs <Miyagawa_Takane> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "東城咲耶子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041619>,
+                <https://ja.dbpedia.org/resource/東城咲耶子> ;
+            lily:performAs <Toki_Kureha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "進藤あまね"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q60989810>,
+                <https://ja.dbpedia.org/page/進藤あまね> ;
+            lily:performAs <Tamba_Akari> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "富田美憂"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q22131362>,
+                <http://ja.dbpedia.org/resource/富田美憂> ;
+            lily:performAs <Sadamori_Himeka> ;
+            # lily:additionalInformation ""@ja ;
+        ],[
+            schema:name "山根綺"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q57314549>,
+                <http://ja.dbpedia.org/resource/山根綺> ;
+            lily:performAs <Homma_Akehi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "船戸ゆり絵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q97347588>,
+                <http://ja.dbpedia.org/resource/船戸ゆり絵> ;
+            lily:performAs <Yokota_Haruna> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "石見舞菜香"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q29479266>,
+                <http://ja.dbpedia.org/resource/石見舞菜香> ;
+            lily:performAs <Shiozaki_Suzume> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "伊達さゆり"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q104181268>,
+                <http://ja.dbpedia.org/resource/伊達さゆり> ;
+            lily:performAs <Ishizuka_Fujino> ;
+            # lily:additionalInformation ""@ja ;
+        ];
+    ] ;
     a lily:Music ;
 .

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -586,7 +586,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
+            lily:resource <https://ja.dbpedia.org/resource/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;
@@ -4456,7 +4456,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            lily:resource  <https://ja.dbpedia.org/page/野中深愛>;
+            lily:resource  <https://ja.dbpedia.org/resource/野中深愛>;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ], [
@@ -5014,7 +5014,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
+            lily:resource <https://ja.dbpedia.org/resource/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ], [
@@ -5155,7 +5155,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
+            lily:resource <https://ja.dbpedia.org/resource/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;
@@ -5338,7 +5338,7 @@
             # lily:additionalInformation ""@ja ;
         ], [
             schema:name "野中深愛"@ja ;
-            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
+            lily:resource <https://ja.dbpedia.org/resource/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;
@@ -5817,7 +5817,7 @@
         schema:name "芹沢千香瑠（CV：野中深愛）"@ja ;
         lily:cast [
             schema:name "野中深愛"@ja ;
-            lily:resource <https://ja.dbpedia.org/page/野中深愛> ;
+            lily:resource <https://ja.dbpedia.org/resource/野中深愛> ;
             lily:performAs <Serizawa_Chikaru> ;
             # lily:additionalInformation ""@ja ;
         ] ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -5941,6 +5941,73 @@
     a lily:Music ;
 .
 
+<Song_Toumei_Diary>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "トウメイダイアリー"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    lily:additionalInformation "アサルトリリィ Last Bullet 2周年テーマ楽曲"@ja ;
+    schema:duration "PT3M40S"^^xsd:duration ;
+    lily:singer [
+        schema:name "一柳隊"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
 <Song_Overcast_Sky>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
@@ -5950,7 +6017,6 @@
     lily:arranger "Islet"@ja ;
     lily:additionalInformation "アサルトリリィ Last Bullet メインストーリー 新章グラン・エプレ編のテーマソング"@ja ;
     schema:duration "PT3M42S"^^xsd:duration ;
-    # schema:inAlbum <> ;
     lily:singer [
         schema:name "新生グラン・エプレ"@ja ;
         lily:cast [


### PR DESCRIPTION
### 概要

#68 

### 情報源

[ブシロードミュージック](https://bushiroad-music.com/titles/assaultlily)

トウメイダイアリー、Overcast Skyの二曲に関してはラスバレゲーム内

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

野中深愛さんのリソースがDBpediaにあったのでついでに追記しました。