### PR TITLE
イルマTGD正式名称・略称の更新

### DIFF
--- a/RDFs/lily_illuma.ttl
+++ b/RDFs/lily_illuma.ttl
@@ -89,7 +89,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q27918100>,
             <http://ja.dbpedia.org/resource/佐藤遥> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -176,7 +176,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q60806778>,
             <http://ja.dbpedia.org/resource/熊沢世莉奈> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -277,7 +277,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q60796806>,
             <http://ja.dbpedia.org/resource/髙橋彩音> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -353,7 +353,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q95162327>,
             <http://ja.dbpedia.org/resource/遥りさ> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -417,7 +417,7 @@
     lily:cast [
         schema:name "西田奈未"@ja ;
         # lily:resource <> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -487,7 +487,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q104538909>,
             <http://ja.dbpedia.org/resource/鵜川もえか> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -558,7 +558,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q24865341>,
             <http://ja.dbpedia.org/resource/松田彩希> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -686,7 +686,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q30945761>,
             <http://ja.dbpedia.org/resource/坂口渚沙> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -753,7 +753,7 @@
     lily:cast [
         schema:name "結木ことは"@ja ;
         # lily:resource <> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -826,7 +826,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q16097304>,
             <http://ja.dbpedia.org/resource/佐々木優佳里> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -892,7 +892,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q74548472>,
             <http://ja.dbpedia.org/resource/集貝はな> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -956,7 +956,7 @@
     lily:cast [
         schema:name "陽高真白"@ja ;
         lily:resource <https://www.wikidata.org/wiki/Q115529746> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -1037,7 +1037,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q28418874>,
             <http://ja.dbpedia.org/resource/北澤早紀> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -1108,7 +1108,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q111113483>,
             <http://ja.dbpedia.org/resource/矢新愛梨> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -1177,7 +1177,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q11517262>,
             <http://ja.dbpedia.org/resource/朝倉ふゆな> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -1248,7 +1248,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q24867742>,
             <http://ja.dbpedia.org/resource/小松穂葉> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -1318,7 +1318,7 @@
     lily:cast [
         schema:name "斎藤愛莉"@ja ;
         # lily:resource <> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;
@@ -1386,7 +1386,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q59072330>,
             <http://ja.dbpedia.org/resource/熊田茜音> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Lily ;

--- a/RDFs/lily_ludovico.ttl
+++ b/RDFs/lily_ludovico.ttl
@@ -1416,7 +1416,7 @@
             <Schwester_No_Himitsu_2021>,
             <Yakusoku_No_Yukue_2022>,
             <Ludovico_Liveshow_2022>,
-            <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+            <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ], [
         schema:name "花奈澪"@ja ;

--- a/RDFs/media_play.ttl
+++ b/RDFs/media_play.ttl
@@ -2798,8 +2798,8 @@
 
 <Assault_Lily_Illuma_Girls_High_School_Of_Arts>
     lily:genre "舞台"@ja ;
-    schema:name "アサルトリリィ・イルマ女子美術高校"@ja ;
-    schema:alternateName "イルマ舞台"@ja ;
+    schema:name "アサルトリリィ・イルマ女子美術高校編 The Gleam of Dawn"@ja ;
+    schema:alternateName "イルマTGD"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:location "かめありリリオホール"^^xsd:string ;
     schema:startDate "2023-04-13"^^xsd:date ;

--- a/RDFs/media_play.ttl
+++ b/RDFs/media_play.ttl
@@ -2796,7 +2796,7 @@
     a lily:Play ;
 .
 
-<Assault_Lily_Illuma_Girls_High_School_Of_Arts>
+<Assault_Lily_Illuma_The_Gleam_of_Dawn>
     lily:genre "舞台"@ja ;
     schema:name "アサルトリリィ・イルマ女子美術高校編 The Gleam of Dawn"@ja ;
     schema:alternateName "イルマTGD"@ja ;

--- a/RDFs/teacher_illuma.ttl
+++ b/RDFs/teacher_illuma.ttl
@@ -66,7 +66,7 @@
         lily:resource
             <https://www.wikidata.org/wiki/Q11465532>,
             <http://ja.dbpedia.org/resource/MoeMi> ;
-        lily:performIn <Assault_Lily_Illuma_Girls_High_School_Of_Arts> ;
+        lily:performIn <Assault_Lily_Illuma_The_Gleam_of_Dawn> ;
         # lily:additionalInformation ""@ja ;
     ] ;
     a lily:Teacher ;


### PR DESCRIPTION
### 概要

イルマTGD(アサルトリリィ・イルマ女子美術高校編 The Gleam of Dawn)の正式名称と略称を更新します

### 情報源

舞台アサルトリリィ公式サイト - https://assaultlily-stage.jp/ticket/

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

以下検討すべきかと思われます (いずれも本PRでは変更していません)

* 正式名称の英文部分をハイフンで区切るかどうか
* ~~リソース名を変更するか~~ → 変更しました
    * 変更する場合、Lemonadeにはリダイレクト処理を仕込むつもりです
