### PR TITLE
イルマ女子のリリィの読み情報の訂正・追加

### DIFF
--- a/RDFs/legion.ttl
+++ b/RDFs/legion.ttl
@@ -690,7 +690,7 @@
         <Kusakabe_Murasame>,
         <Yoshii_Kasumiko>,
         <Hidai_Miyazu>,
-        <Iwaya_Kokori>,
+        <Iwaya_Kukuri>,
         <Nakabayashi_Kaina> ;
     lily:submember
         <Ueda_Imari> ;

--- a/RDFs/lily_illuma.ttl
+++ b/RDFs/lily_illuma.ttl
@@ -564,16 +564,16 @@
     a lily:Lily ;
 .
 
-<Iwaya_Kokori>
+<Iwaya_Kukuri>
     rdfs:label "巌谷紅々李"^^xsd:string ;
     schema:familyName "巌谷"@ja ; #, ""@en ;
-    # lily:familyNameKana ""@ja ;
+    lily:familyNameKana "いわや"@ja ;
     # schema:additionalName ""@ja, ""@en ;
     # lily:additionalNameKana ""@ja ;
     schema:givenName "紅々李"@ja ; #, ""@en ;
-    # lily:givenNameKana ""@ja ;
+    lily:givenNameKana "くくり"@ja ;
     schema:name "巌谷紅々李"@ja ; #, ""@en ;
-    # lily:nameKana ""@ja ;
+    lily:nameKana "いわやくくり"@ja ;
     # lily:anotherName ""@ja ;
     # foaf:age ""^^xsd:integer ;
     # schema:height ""^^xsd:float ;

--- a/RDFs/lily_illuma.ttl
+++ b/RDFs/lily_illuma.ttl
@@ -366,9 +366,9 @@
     # schema:additionalName ""@ja, ""@en ;
     # lily:additionalNameKana ""@ja ;
     schema:givenName "美夜受"@ja, "Miyazu"@en ;
-    lily:givenNameKana "みやず"@ja ;
+    lily:givenNameKana "みやづ"@ja ;
     schema:name "比田井美夜受"@ja, "Hidai Miyazu"@en ;
-    lily:nameKana "ひだいみやず"@ja ;
+    lily:nameKana "ひだいみやづ"@ja ;
     lily:anotherName "黒い妖精"@ja ;
     foaf:age "16"^^xsd:integer ;
     schema:height "155.0"^^xsd:float ;


### PR DESCRIPTION
### 概要

* 06723586a886178e16330f012989783fc58fc9a0 - 比田井美夜受の読みを訂正 (ひだいみや**ず**→ひだいみや**づ**)
* f7048a77ddc6426ef25bb45d63e4fd01dcf1300e - 巌谷紅々李の読み情報の追加 (いわやくくり)

### 情報源

* 比田井美夜受の読み - https://twitter.com/assault_lily/status/1576944531009740801
* 巌谷紅々李の読み - https://twitter.com/assault_lily/status/1648703972658778112

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項