### PR TITLE
クエレブレのリリィの情報を追加

### DIFF
--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -300,7 +300,8 @@
         <Asanaga_Ichigo>,
         <Ushida_Watsuki>,
         <Yokota_Haruna>,
-        <Kawabata_Hotaru> ;
+        <Kawabata_Hotaru>,
+        <Makino_Mitake> ;
     lily:isVariantOf <Tyrfing_Prototype> ;
     schema:isSimilarTo
         <Tyrfing_type_R>,
@@ -413,7 +414,8 @@
         <Yumeno_Kanon>,
         <Rosalinde_Friedegunde_von_Otto>,
         <Watanabe_Akane>,
-        <Asanaga_Ichigo> ;
+        <Asanaga_Ichigo>,
+        <Kagawa_Makina> ;
     a lily:Charm ;
 .
 

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -576,7 +576,7 @@
     # lily:skillerVal ""^^xsd:integer ;
     lily:rareSkill "円環の御手"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
-    lily:isBoosted false ;
+    lily:isBoosted true ;
     # lily:boostedSkill ""^^xsd:string ;
     # lily:charm [
     #    lily:resource <> ;

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -672,10 +672,14 @@
         # lily:resource <> ;
         # lily:additionalInformation ""@ja ;
     # ] ;
-    # lily:cast [
-    #    lily:resource <> ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:cast [
+        schema:name "指出毬亜"@ja ;
+        lily:resource
+            <https://www.wikidata.org/wiki/Q28689219>,
+            <https://ja.dbpedia.org/resource/指出毬亜> ;
+        lily:performIn <Assault_Lily_Last_Bullet> ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     a lily:Lily ;
 .
 

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -605,10 +605,14 @@
         # lily:resource <> ;
         # lily:additionalInformation ""@ja ;
     # ] ;
-    # lily:cast [
-    #    lily:resource <> ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:cast [
+        schema:name "木野日菜"@ja ;
+        lily:resource
+            <https://www.wikidata.org/wiki/Q23948726>,
+            <https://ja.dbpedia.org/resource/木野日菜> ;
+        lily:performIn <Assault_Lily_Last_Bullet> ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     a lily:Lily ;
 .
 

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -595,7 +595,7 @@
     # lily:pastLegion <> ;
     # lily:taskforce <> ;
     # lily:pastTaskforce <> ;
-    # lily:roomMate <> ;
+    lily:roomMate <Morimoto_Yuni> ;
     # schema:parent <> ;
     # schema:sibling [
     #    lily:resource <> ;
@@ -662,7 +662,7 @@
     # lily:pastLegion <> ;
     # lily:taskforce <> ;
     # lily:pastTaskforce <> ;
-    # lily:roomMate <> ;
+    lily:roomMate <Kagawa_Makina> ;
     # schema:parent <> ;
     # schema:sibling [
     #    lily:resource <> ;

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -511,11 +511,11 @@
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted false ;
     # lily:boostedSkill ""^^xsd:string ;
-    # lily:charm [
-    #    lily:resource <> ;
-    #    lily:usedIn ""^^xsd:string ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:charm [
+        lily:resource <Tyrfing_type_T> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     lily:garden "エレンスゲ女学園"^^xsd:string ;
     # lily:rank ""^^xsd:integer ;
     # lily:gardenDepartment ""^^xsd:string ;
@@ -578,11 +578,11 @@
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted true ;
     # lily:boostedSkill ""^^xsd:string ;
-    # lily:charm [
-    #    lily:resource <> ;
-    #    lily:usedIn ""^^xsd:string ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:charm [
+        lily:resource <Asterion> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     lily:garden "エレンスゲ女学園"^^xsd:string ;
     # lily:rank ""^^xsd:integer ;
     # lily:gardenDepartment ""^^xsd:string ;


### PR DESCRIPTION
### 概要

クエレブレのリリィの情報を追加

### 情報源

蒔菜が強化リリィであることに関しての二水ちゃんのツイート↓
https://twitter.com/assault_lily/status/1649429990931308544

ラスバレ内イベント「メインストーリー新章プレストーリー 牧野美岳&賀川蒔菜編」

ラスバレ放送局 第59回↓（公式のまとめ）
https://assaultlily.jp/news/info/3474/

プレストーリーに関してはツイートにまとめてあります↓（最初の画像はアステリオンマギカノンの説明です）
https://twitter.com/nagisan_2nd/status/1651195581573005314

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

ルームメイトの記述に関しては、蒔菜が美岳を自分の部屋に誘い、その後部屋に入った結爾が「わたしの部屋でもある」と発言していたので判断しました。

二つ目のツイートの画像に記載されている藍のアルケミートレースに関しては、情報が少ないので保留しました。
