### PR TITLE
佐々木藍・松村優珂・牧野美岳・賀川蒔菜・森本結爾のプロフィールを更新

### DIFF
--- a/.rdflint/rdflint-suppress.yml
+++ b/.rdflint/rdflint-suppress.yml
@@ -433,3 +433,13 @@ RDFs/charm.ttl:
     message: 'Data LanguageType not matched: lang is en, but Adámas (line: 1381, col:
         28, triple: https://luciadb.assaultlily.com/rdf/RDFs/detail/Adamas - http://schema.org/name
         - "Adámas"@en)'
+RDFs/lily_herensuge.ttl:
+  - key: com.github.imas.rdflint.validator.impl.predictedOutlier
+    level: INFO
+    line: '141'
+    column: '15'
+    subject: https://luciadb.assaultlily.com/rdf/RDFs/detail/Sasaki_Ran
+    predicate: https://luciadb.assaultlily.com/rdf/IRIs/lily_schema.ttl#rank
+    object: '"47"^^http://www.w3.org/2001/XMLSchema#integer'
+    message: 'Outlier found: 47 (line: 141, col: 15, triple: https://luciadb.assaultlily.com/rdf/RDFs/detail/Sasaki_Ran
+        - https://luciadb.assaultlily.com/rdf/IRIs/lily_schema.ttl#rank - "47"^^http://www.w3.org/2001/XMLSchema#integer)'

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -105,7 +105,7 @@
     lily:givenNameKana "らん"@ja ;
     schema:name "佐々木藍"@ja, "Sasaki Ran"@en ;
     lily:nameKana "ささきらん"@ja ;
-    # lily:anotherName ""@ja ;
+    lily:anotherName "ヒュージの姫"@ja ;
     foaf:age "15"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
@@ -129,7 +129,7 @@
     lily:rareSkill "ルナティックトランサー"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted true ;
-    # lily:boostedSkill ""^^xsd:string ;
+    lily:boostedSkill "アルケミートレース"^^xsd:string ;
     lily:charm [
         lily:resource <Mondragon> ;
         lily:usedIn

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -424,9 +424,14 @@
     # schema:birthPlace ""@ja, ""@en ;
     lily:favorite
         "フェレット"@ja,
-        "カワウソ"@ja ;
+        "カワウソ"@ja,
+        "ウニ（寿司）"@ja ;
     lily:notGood "寒さ"@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:hobby_talent
+        "多肉植物の育成"@ja,
+        "ファッション"@ja,
+        "アンティーク雑貨の収集"@ja,
+        "歌"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
     lily:rareSkill "ヘリオスフィア"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -499,15 +499,15 @@
     foaf:age "16"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--02-09"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "A"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
     lily:favorite "キャンディ"@ja ;
-    # lily:notGood ""@ja ;
+    lily:notGood "機械やIT機器の操作"@ja ;
     lily:hobby_talent
         "イラスト"@ja,
         "読書"@ja ;
@@ -522,7 +522,7 @@
         # lily:additionalInformation ""@ja ;
     ] ;
     lily:garden "エレンスゲ女学園"^^xsd:string ;
-    # lily:rank ""^^xsd:integer ;
+    lily:rank "80"^^xsd:integer ;
     # lily:gardenDepartment ""^^xsd:string ;
     lily:grade "11"^^xsd:integer ;
     # lily:class ""^^xsd:string ;
@@ -568,16 +568,16 @@
     foaf:age "15"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--03-05"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "AB"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
     lily:favorite "風船ガム"@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:notGood "整理整頓"@ja ;
+    lily:hobby_talent "テレビゲーム"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
     lily:rareSkill "円環の御手"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
@@ -589,7 +589,7 @@
         # lily:additionalInformation ""@ja ;
     ] ;
     lily:garden "エレンスゲ女学園"^^xsd:string ;
-    # lily:rank ""^^xsd:integer ;
+    lily:rank "15"^^xsd:integer ;
     # lily:gardenDepartment ""^^xsd:string ;
     lily:grade "10"^^xsd:integer ;
     # lily:class ""^^xsd:string ;

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -642,7 +642,7 @@
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
-    # lily:favorite ""@ja ;
+    lily:favorite "古生物、恐竜"@ja ;
     # lily:notGood ""@ja ;
     # lily:hobby_talent ""@ja ;
     # lily:skillerVal ""^^xsd:integer ;


### PR DESCRIPTION
### 概要

ラスバレ内の情報からのプロフィール更新です。

### 情報源

ラスバレ内イベント「竜のシャナと楯の乙女」

ラスバレ内キャラプロフィール

ラスバレ放送局 in TGS2022

上記のソースはこちらにまとめてあります↓
https://twitter.com/nagisan_2nd/status/1652999471494463489

森本結爾の好きなものに関しては、二水ちゃんのツイートです。
https://twitter.com/assault_lily/status/1635309484477419522

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [x] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

牧野美岳の序列の影響で佐々木藍の序列にrdflintの外れ値エラーが発生しますが、正常な値であるのでエラー抑制処置を行いました。