### PR TITLE
石塚藤乃・賀川蒔菜の使用CHARMを追加

### DIFF
--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -147,7 +147,9 @@
         <Funada_Ui>,
         <Hirose_Minato>,
         <Takasuga_Tsukushi>,
-        <Banshoya_Ena> ;
+        <Banshoya_Ena>,
+        <Ishizuka_Fujino>,
+        <Kagawa_Makina> ;
     lily:isVariantOf <Gungnir> ;
     a lily:Charm ;
 .

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -587,6 +587,10 @@
         lily:resource <Asterion> ;
         lily:usedIn "ラスバレ"^^xsd:string ;
         # lily:additionalInformation ""@ja ;
+    ], [
+        lily:resource <Gungnir_Carbin> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
     ] ;
     lily:garden "エレンスゲ女学園"^^xsd:string ;
     lily:rank "15"^^xsd:integer ;

--- a/RDFs/lily_kamba.ttl
+++ b/RDFs/lily_kamba.ttl
@@ -706,6 +706,10 @@
         lily:resource <Chrysaor> ;
         lily:usedIn "ラスバレ"^^xsd:string ;
         # lily:additionalInformation ""@ja ;
+    ], [
+        lily:resource <Gungnir_Carbin> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
     ] ;
     lily:garden "神庭女子藝術高校"^^xsd:string ;
     # lily:gardenDepartment ""^^xsd:string ;


### PR DESCRIPTION
### 概要

石塚藤乃、賀川蒔菜の使用CHARM「グングニル・カービン」の追加

追加漏れです...すみません🙇

### 情報源

ラスバレ

[ゲーム内お知らせのアーカイブ - 石塚藤乃](https://allb-news.sakuraweb.com/3569/#:~:text=%E2%80%BB%E3%82%B5%E3%83%95%E3%82%99charm%E3%80%8C%E3%82%AF%E3%82%99%E3%83%B3%E3%82%AF%E3%82%99%E3%83%8B%E3%83%AB%E3%82%AB%E3%83%BC%E3%83%92%E3%82%99%E3%83%B3sp.if%E3%80%8D%E3%82%82%E7%8D%B2%E5%BE%97%E3%81%97%E3%81%BE%E3%81%99%E3%80%82)

[ゲーム内お知らせのアーカイブ - 賀川蒔菜](https://allb-news.sakuraweb.com/3756/#:~:text=%E2%80%BB%E3%82%B5%E3%83%95%E3%82%99charm%E3%80%8C%E3%82%AF%E3%82%99%E3%83%B3%E3%82%AF%E3%82%99%E3%83%8B%E3%83%AB%E3%82%AB%E3%83%BC%E3%83%92%E3%82%99%E3%83%B3sp.km%E3%80%8D%E3%82%82%E7%8D%B2%E5%BE%97%E3%81%97%E3%81%BE%E3%81%99%E3%80%82)

ページ中ほどに記述されています。

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある