### PR TITLE
一部楽曲情報の修正と新曲の追加

### DIFF
--- a/RDFs/media_concert.ttl
+++ b/RDFs/media_concert.ttl
@@ -4984,7 +4984,7 @@
     ], [
         schema:name "つきあかりのコントラスト"@ja ;
         lily:listOrder "5"^^xsd:integer ;
-        lily:resource <Song_Tsukiakarino_Contrast> ;
+        lily:resource <Song_Tsukiakari_No_Contrast> ;
         lily:cast [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;
@@ -5030,7 +5030,7 @@
     ], [
         schema:name "リリィ♡リリィ♡GOGOリリィ♡"@ja ;
         lily:listOrder "8"^^xsd:integer ;
-        lily:resource <Song_Lily_Lily_GoGo_Lily> ;
+        lily:resource <Song_Lily_Lily_Go_Go_Lily> ;
         lily:cast [
             schema:name "井澤美香子"@ja ;
             lily:resource
@@ -5180,7 +5180,7 @@
     ], [
         schema:name "君の手を離さない ～BOUQUET Ver.～"@ja ;
         lily:listOrder "12"^^xsd:integer ;
-        lily:resource <Song_Kimino_Tewo_Hanasanai_Bouquet_Ver> ;
+        lily:resource <Song_Kimino_Te_Wo_Hanasanai_Bouquet_Ver> ;
         lily:cast [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;
@@ -5291,7 +5291,7 @@
     ], [
         schema:name "蕾の中の奇跡"@ja ;
         lily:listOrder "14"^^xsd:integer ;
-        lily:resource <Song_Tsubomino_Nakano_Kiseki_Hitotuyanagitai_Version> ;
+        lily:resource <Song_Tsubomi_No_Naka_No_Kiseki_Radgrid_Ver> ;
         lily:cast [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;
@@ -5750,7 +5750,7 @@
     ], [
         schema:name "つきあかりのコントラスト"@ja ;
         lily:listOrder "5"^^xsd:integer ;
-        lily:resource <Song_Tsukiakarino_Contrast> ;
+        lily:resource <Song_Tsukiakari_No_Contrast> ;
         lily:cast [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;
@@ -5796,7 +5796,7 @@
     ], [
         schema:name "リリィ♡リリィ♡GOGOリリィ♡"@ja ;
         lily:listOrder "8"^^xsd:integer ;
-        lily:resource <Song_Lily_Lily_GoGo_Lily> ;
+        lily:resource <Song_Lily_Lily_Go_Go_Lily> ;
         lily:cast [
             schema:name "井澤美香子"@ja ;
             lily:resource
@@ -6057,7 +6057,7 @@
     ], [
         schema:name "蕾の中の奇跡"@ja ;
         lily:listOrder "14"^^xsd:integer ;
-        lily:resource <Song_Tsubomino_Nakano_Kiseki_Hitotuyanagitai_Version> ;
+        lily:resource <Song_Tsubomi_No_Naka_No_Kiseki_Radgrid_Ver> ;
         lily:cast [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -4156,7 +4156,7 @@
             lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
             lily:performAs <Shirai_Yuyu> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -4286,7 +4286,7 @@
                 <http://ja.dbpedia.org/resource/伊藤美来> ;
             lily:performAs <Hitotsuyanagi_Yuri> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -4466,7 +4466,7 @@
                 <http://ja.dbpedia.org/resource/佃井皆美> ;
             lily:performAs <Gozen> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -4539,7 +4539,6 @@
     a lily:Music ;
 .
 
-
 <Song_Rainbow>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
@@ -4563,7 +4562,7 @@
                 <http://ja.dbpedia.org/resource/岩田陽葵> ;
             lily:performAs <Yoshimura_Thi_Mai> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -4589,7 +4588,7 @@
             lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
             lily:performAs <Ando_Tazusa> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -4615,7 +4614,7 @@
             lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
             lily:performAs <Wang_Yujia> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -4650,7 +4649,7 @@
                 <http://ja.dbpedia.org/resource/高橋花林> ;
             lily:performAs <Miliam_Hildegard_von_Guropius> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -5048,7 +5047,7 @@
                 <http://ja.dbpedia.org/resource/富田美憂> ;
             lily:performAs <Sadamori_Himeka> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .
@@ -6082,7 +6081,7 @@
                 <http://ja.dbpedia.org/resource/伊達さゆり> ;
             lily:performAs <Ishizuka_Fujino> ;
             # lily:additionalInformation ""@ja ;
-        ];
+        ] ;
     ] ;
     a lily:Music ;
 .

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -4550,7 +4550,7 @@
     # lily:additionalInformation ""@ja ;
     schema:duration "PT4M52S"^^xsd:duration ;
     lily:singer [
-        schema:name "白井夢結＆吉村・Thi・梅（CV：夏吉ゆうこ＆岩田陽葵）"@ja ;
+        schema:name "白井夢結（CV：夏吉ゆうこ）＆吉村・Thi・梅（CV：岩田陽葵）"@ja ;
         lily:cast [
             schema:name "夏吉ゆうこ"@ja ;
             lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
@@ -4578,7 +4578,7 @@
     # lily:additionalInformation ""@ja ;
     schema:duration "PT4M59S"^^xsd:duration ;
     lily:singer [
-        schema:name "一柳梨璃＆安藤鶴紗（CV：赤尾ひかる＆紡木吏佐）"@ja ;
+        schema:name "一柳梨璃（CV：赤尾ひかる）＆安藤鶴紗（CV：紡木吏佐）"@ja ;
         lily:cast [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;
@@ -4604,7 +4604,7 @@
     # lily:additionalInformation ""@ja ;
     schema:duration "PT4M50S"^^xsd:duration ;
     lily:singer [
-        schema:name "郭神琳＆王雨嘉（CV：星守紗凪＆遠野ひかる）"@ja ;
+        schema:name "郭神琳（CV：星守紗凪）＆王雨嘉（CV：遠野ひかる）"@ja ;
         lily:cast [
             schema:name "星守紗凪"@ja ;
             lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
@@ -4630,7 +4630,7 @@
     # lily:additionalInformation ""@ja ;
     schema:duration "PT3M16S"^^xsd:duration ;
     lily:singer [
-        schema:name "楓・J・ヌーベル＆二川二水＆ミリアム・ヒルデガルド・v・グロピウス（CV：井澤美香子＆西本りみ＆高橋花林）"@ja ;
+        schema:name "楓・J・ヌーベル（CV：井澤美香子）＆二川二水（CV：西本りみ）＆ミリアム・ヒルデガルド・v・グロピウス（CV：高橋花林）"@ja ;
         lily:cast [
             schema:name "井澤美香子"@ja ;
             lily:resource
@@ -4889,7 +4889,7 @@
         <Neunt_Praeludium_Last_Bullet_Mix_Normal_B>,
         <Neunt_Praeludium_Last_Bullet_Mix_Normal_C> ;
     lily:singer [
-        schema:name "一柳梨璃＆白井夢結＆相澤一葉＆今叶星（CV：赤尾ひかる＆夏吉ゆうこ＆藤井彩加＆前田佳織里）"@ja ;
+        schema:name "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）＆相澤一葉（CV：藤井彩加）＆今叶星（CV：前田佳織里）"@ja ;
         lily:cast [
             schema:name "赤尾ひかる"@ja ;
             lily:resource <http://www.wikidata.org/entity/Q28685785> ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -4126,7 +4126,7 @@
     lily:format "デジタルシングル"@ja ;
     schema:datePublished "2020-10-31"^^xsd:date ;
     schema:numTracks "1"^^xsd:integer ;
-    schema:timeRequired "PT4M"^^xsd:duration ;
+    schema:timeRequired "PT4M28S"^^xsd:duration ;
     lily:track [
         lily:listOrder "1"^^xsd:integer ;
         lily:song <Song_Heart_Heart> ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -4320,7 +4320,7 @@
     lily:lyricist "谷ナオキ"@ja ;
     lily:composer "谷ナオキ"@ja ;
     lily:arranger "谷ナオキ"@ja ;
-    lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第12話挿入歌、舞台「アサルトリリィ The Fateful Gift」主題歌"@ja ;
+    lily:additionalInformation "舞台「アサルトリリィ The Fateful Gift」主題歌"@ja ;
     schema:duration "PT5M18S"^^xsd:duration ;
     schema:inAlbum <Kimino_Te_Wo_Hanasanai> ;
     lily:singer [

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -5940,6 +5940,25 @@
     a lily:Music ;
 .
 
+<Toumei_Diary>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "トウメイダイアリー"@ja ;
+    # lily:additionalInformation ""@ja ;
+    lily:musicProducer "タノウエマモル"@ja ;
+    lily:artist "一柳隊"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "グリーエンターテインメント"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2023-06-28"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT3M43S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Toumei_Diary> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
 <Song_Toumei_Diary>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
@@ -5948,7 +5967,8 @@
     lily:composer "神田ジョン"@ja ;
     lily:arranger "神田ジョン"@ja ;
     lily:additionalInformation "アサルトリリィ Last Bullet 2周年テーマ楽曲"@ja ;
-    schema:duration "PT3M40S"^^xsd:duration ;
+    schema:duration "PT3M43S"^^xsd:duration ;
+    schema:inAlbum <Toumei_Diary> ;
     lily:singer [
         schema:name "一柳隊"@ja ;
         lily:cast [

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -4291,7 +4291,7 @@
     a lily:Music ;
 .
 
-<Kimino_Tewo_Hanasanai>
+<Kimino_Te_Wo_Hanasanai>
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "君の手を離さない"@ja ;
     # lily:additionalInformation ""@ja ;
@@ -4305,15 +4305,15 @@
     schema:timeRequired "PT10M36S"^^xsd:duration ;
     lily:track [
         lily:listOrder "1"^^xsd:integer ;
-        lily:song <Song_Kimino_Tewo_Hanasanai> ;
+        lily:song <Song_Kimino_Te_Wo_Hanasanai> ;
     ], [
         lily:listOrder "2"^^xsd:integer ;
-        lily:song <Song_Kimino_Tewo_Hanasanai_Bouquet_Ver>
+        lily:song <Song_Kimino_Te_Wo_Hanasanai_Bouquet_Ver>
     ] ;
     a lily:MusicAlbum ;
 .
 
-<Song_Kimino_Tewo_Hanasanai>
+<Song_Kimino_Te_Wo_Hanasanai>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "君の手を離さない"@ja ;
@@ -4322,7 +4322,7 @@
     lily:arranger "谷ナオキ"@ja ;
     lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第12話挿入歌、舞台「アサルトリリィ The Fateful Gift」主題歌"@ja ;
     schema:duration "PT5M18S"^^xsd:duration ;
-    schema:inAlbum <Kimino_Tewo_Hanasanai> ;
+    schema:inAlbum <Kimino_Te_Wo_Hanasanai> ;
     lily:singer [
         schema:name "一柳隊＆ルド女選抜＆御台場選抜＆相模女子選抜＆ヘルヴォル＆御前"@ja ;
         lily:cast [
@@ -4471,7 +4471,7 @@
     a lily:Music ;
 .
 
-<Song_Kimino_Tewo_Hanasanai_Bouquet_Ver>
+<Song_Kimino_Te_Wo_Hanasanai_Bouquet_Ver>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "君の手を離さない ～BOUQUET Ver.～"@ja ;
@@ -4480,7 +4480,7 @@
     lily:arranger "谷ナオキ"@ja ;
     lily:additionalInformation "TVアニメ「アサルトリリィ BOUQUET」第12話挿入歌"@ja ;
     schema:duration "PT5M18S"^^xsd:duration ;
-    schema:inAlbum <Kimino_Tewo_Hanasanai> ;
+    schema:inAlbum <Kimino_Te_Wo_Hanasanai> ;
     lily:singer [
         schema:name "一柳隊"@ja ;
         lily:cast [
@@ -4568,7 +4568,7 @@
     a lily:Music ;
 .
 
-<Song_Tsukiakarino_Contrast>
+<Song_Tsukiakari_No_Contrast>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "つきあかりのコントラスト"@ja ;
@@ -4620,7 +4620,7 @@
     a lily:Music ;
 .
 
-<Song_Lily_Lily_GoGo_Lily>
+<Song_Lily_Lily_Go_Go_Lily>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "リリィ♡リリィ♡GOGOリリィ♡"@ja ;
@@ -4761,13 +4761,13 @@
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
     ], [
         lily:listOrder "2"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki> ;
     ], [
         lily:listOrder "3"^^xsd:integer ;
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
     ], [
         lily:listOrder "4"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki_Instrumental> ;
     ] ;
     a lily:MusicAlbum ;
 .
@@ -4789,19 +4789,19 @@
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
     ], [
         lily:listOrder "2"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki_Hitotuyanagitai_Version> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki_Radgrid_Ver> ;
     ], [
         lily:listOrder "3"^^xsd:integer ;
-        lily:song <Song_Omoidega_Afureteru> ;
+        lily:song <Song_Omoide_Ga_Afureteru> ;
     ], [
         lily:listOrder "4"^^xsd:integer ;
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
     ], [
         lily:listOrder "5"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki_Instrumental> ;
     ], [
         lily:listOrder "6"^^xsd:integer ;
-        lily:song <Song_Omoidega_Afureteru_Instrumental> ;
+        lily:song <Song_Omoide_Ga_Afureteru_Instrumental> ;
     ] ;
     a lily:MusicAlbum ;
 .
@@ -4823,7 +4823,7 @@
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
     ], [
         lily:listOrder "2"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki_Hervor_Version> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki_Hervarar_Ver> ;
     ], [
         lily:listOrder "3"^^xsd:integer ;
         lily:song <Song_Resonant_Hearts> ;
@@ -4832,7 +4832,7 @@
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
     ], [
         lily:listOrder "5"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki_Instrumental> ;
     ], [
         lily:listOrder "6"^^xsd:integer ;
         lily:song <Song_Resonant_Hearts_Instrumental> ;
@@ -4857,7 +4857,7 @@
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix> ;
     ], [
         lily:listOrder "2"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki_Gran_Eple_Version> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki_Gran_Eple_Ver> ;
     ], [
         lily:listOrder "3"^^xsd:integer ;
         lily:song <Song_Treasure_Every_Day> ;
@@ -4866,7 +4866,7 @@
         lily:song <Song_Neunt_Praeludium_Last_Bullet_Mix_Instrumental> ;
     ], [
         lily:listOrder "5"^^xsd:integer ;
-        lily:song <Song_Tsubomino_Nakano_Kiseki_Instrumental> ;
+        lily:song <Song_Tsubomi_No_Naka_No_Kiseki_Instrumental> ;
     ], [
         lily:listOrder "6"^^xsd:integer ;
         lily:song <Song_Treasure_Every_Day_Instrumental> ;
@@ -4929,7 +4929,7 @@
     a lily:Music ;
 .
 
-<Song_Tsubomino_Nakano_Kiseki>
+<Song_Tsubomi_No_Naka_No_Kiseki>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "蕾の中の奇跡"@ja ;
@@ -5053,7 +5053,7 @@
     a lily:Music ;
 .
 
-<Song_Tsubomino_Nakano_Kiseki_Hitotuyanagitai_Version>
+<Song_Tsubomi_No_Naka_No_Kiseki_Radgrid_Ver>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "蕾の中の奇跡"@ja ;
@@ -5121,7 +5121,7 @@
     a lily:Music ;
 .
 
-<Song_Tsubomino_Nakano_Kiseki_Hervor_Version>
+<Song_Tsubomi_No_Naka_No_Kiseki_Hervarar_Ver>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "蕾の中の奇跡"@ja ;
@@ -5163,7 +5163,7 @@
     a lily:Music ;
 .
 
-<Song_Tsubomino_Nakano_Kiseki_Gran_Eple_Version>
+<Song_Tsubomi_No_Naka_No_Kiseki_Gran_Eple_Ver>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "蕾の中の奇跡"@ja ;
@@ -5211,7 +5211,7 @@
     a lily:Music ;
 .
 
-<Song_Tsubomino_Nakano_Kiseki_Instrumental>
+<Song_Tsubomi_No_Naka_No_Kiseki_Instrumental>
     lily:genre "歌"@ja ;
     lily:inLanguage "ja-JP"^^xsd:language ;
     schema:name "蕾の中の奇跡 -instrumental-"@ja ;
@@ -5225,7 +5225,7 @@
     a lily:Music ;
 .
 
-<Song_Omoidega_Afureteru>
+<Song_Omoide_Ga_Afureteru>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "思い出が溢れてる"@ja ;
@@ -5293,7 +5293,7 @@
     a lily:Music ;
 .
 
-<Song_Omoidega_Afureteru_Instrumental>
+<Song_Omoide_Ga_Afureteru_Instrumental>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "想い出が溢れてる -instrumental-"@ja ;
@@ -5453,7 +5453,7 @@
         lily:song <Song_Everlasting> ;
     ], [
         lily:listOrder "9"^^xsd:integer ;
-        lily:song <Song_Unmeino_Filament> ;
+        lily:song <Song_Unmei_No_Filament> ;
     ], [
         lily:listOrder "10"^^xsd:integer ;
         lily:song <Song_Cherish> ;
@@ -5624,7 +5624,7 @@
     a lily:Music ;
 .
 
-<Song_Unmeino_Filament>
+<Song_Unmei_No_Filament>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "運命のFilament"@ja ;
@@ -5698,7 +5698,7 @@
         lily:song <Song_Hope> ;
     ], [
         lily:listOrder "6"^^xsd:integer ;
-        lily:song <Song_Maka_Fushigiwo_Daisukida> ;
+        lily:song <Song_Maka_Fushigi_Wo_Daisukida> ;
     ], [
         lily:listOrder "7"^^xsd:integer ;
         lily:song <Song_Preserved_Idol> ;
@@ -5825,7 +5825,7 @@
     a lily:Music ;
 .
 
-<Song_Maka_Fushigiwo_Daisukida>
+<Song_Maka_Fushigi_Wo_Daisukida>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
     schema:name "摩訶不思議をダイスキダ"@ja ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -6184,3 +6184,57 @@
     ] ;
     a lily:Music ;
 .
+
+<Song_Wish_Drop>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Wish Drop"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "鈴谷皆人"@ja ;
+    lily:arranger "鈴谷皆人"@ja ;
+    lily:additionalInformation "ラスバレ2.5周年 リリサマ!! テーマ楽曲"@ja ;
+    schema:duration "PT4M27S"^^xsd:duration ;
+    lily:singer [
+        schema:name "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）＆相澤一葉（CV：藤井彩加）＆飯島恋花（CV：石飛恵里花）＆今叶星（CV：前田佳織里）＆宮川高嶺（CV：礒部花凜）"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "藤井彩加"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q28068428>,
+                <https://ja.dbpedia.org/resource/藤井彩加> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "石飛恵里花"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q51166206>,
+                <https://ja.dbpedia.org/resource/石飛恵里花> ;
+            lily:performAs <Iijima_Renka> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "前田佳織里"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q41693141>,
+                <https://ja.dbpedia.org/page/前田佳織里>;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "磯部花凜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q18990383>,
+                <https://ja.dbpedia.org/resource/礒部花凜> ;
+            lily:performAs <Miyagawa_Takane> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.


### PR DESCRIPTION
### 概要

#93 にて誤っていた箇所の修正と、新曲「Wish Drop」、デジタルシングル「トウメイダイアリー」の情報を追加します。

・[Heart+Heartのアルバム再生時間を修正](https://github.com/Assault-Lily/LuciaDB/commit/8675164023b1351d10e09bbf0f0d60a88b4c2c8f)
アルバム再生時間と収録曲の再生時間が一致していなかったので修正しました。

・[一部楽曲のリソース名の修正](https://github.com/Assault-Lily/LuciaDB/commit/ac3a251379fecf8758d469c93eddb8b692fa30ad)
従来楽曲の命名規則に合うようリソース名を変更しました。

・[「君の手を離さない」の追加情報欄を修正](https://github.com/Assault-Lily/LuciaDB/commit/e27e791b0b0cbebf2020bcc3da02375fd7b41bfd)
アニメ12話のEDはBouquet Ver.なので該当する記述を削除しました。

・[一部楽曲の歌手名を修正](https://github.com/Assault-Lily/LuciaDB/commit/23aadd04645d600f58053319c853f2a58ef40d80)
こちらも既存楽曲に合うように記述を修正しました。

・[ファイル記述の修正](https://github.com/Assault-Lily/LuciaDB/commit/a53a5b5664c9d0e08665140c7c5d14108a2b65a1)
キャストさんのリストのセミコロンとの間に一部空白が挿入されていなかったので修正しました。

・[デジタルシングル「トウメイダイアリー」の追加](https://github.com/Assault-Lily/LuciaDB/commit/b3d3cadf4b8791f6f8931ece9eda468ff44e1123)

・[曲「Wish Drop」の追加](https://github.com/Assault-Lily/LuciaDB/commit/6ac9ba0985a0747b59ceda9a2b6a5c609c8499a5)

### 情報源

・デジタルシングル「トウメイダイアリー」の追加
アサルトリリィプロジェクト 公式アカウント（ https://twitter.com/assaultlily_pj/status/1684897742248976384?s=20 ）


・「Wish Drop」の追加
ラスバレゲーム内（スクリーンショット→ https://twitter.com/nagisan_2nd/status/1700487959454298510?s=20 ）


### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

特にないです。
