### PR TITLE
キャラプロフィールの更新、デジタルシングルの追加

### DIFF
--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -635,7 +635,8 @@
         <Sadamori_Himeka>,
         <Uchida_Mayuri>,
         <Hata_Matsuri>,
-        <Tsukioka_Momiji> ;
+        <Tsukioka_Momiji>,
+        <Hayakawa_Yahiro> ;
     a lily:Charm ;
 .
 

--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -515,7 +515,9 @@
     # lily:generation ""^^xsd:decimal ;
     # lily:requiredSkillerVal ""^^xsd:integer ;
     schema:manufacturer <Auniamendi_Systemas> ;
-    lily:user <Sasaki_Ran> ;
+    lily:user
+        <Sasaki_Ran>,
+        <Kariya_Higure> ;
     a lily:Charm ;
 .
 

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -622,10 +622,10 @@
     #    lily:resource <> ;
     #    lily:additionalInformation ""@ja ;
     # ] ;
-    # lily:relationship [
-        # lily:resource <> ;
-        # lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:relationship [
+        lily:resource <Kariya_Higure> ;
+        lily:additionalInformation "慕っている"@ja ;
+    ] ;
     lily:cast [
         schema:name "木野日菜"@ja ;
         lily:resource
@@ -720,18 +720,20 @@
     foaf:age "16"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--05-10"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "O"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
     lily:favorite
         "バイク"@ja,
         "山登り"@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:notGood "勉強"@ja ;
+    lily:hobby_talent
+        "登山"@ja,
+        "ハイキング"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
     lily:rareSkill "テスタメント"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
@@ -743,7 +745,7 @@
     #    lily:additionalInformation ""@ja ;
     # ] ;
     lily:garden "エレンスゲ女学園"^^xsd:string ;
-    # lily:rank ""^^xsd:integer ;
+    lily:rank "43"^^xsd:integer ;
     # lily:gardenDepartment ""^^xsd:string ;
     lily:grade "11"^^xsd:integer ;
     # lily:class ""^^xsd:string ;
@@ -760,10 +762,10 @@
     #    lily:resource <> ;
     #    lily:additionalInformation ""@ja ;
     # ] ;
-    # lily:relationship [
-        # lily:resource <> ;
-        # lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:relationship [
+        lily:resource <Kagawa_Makina> ;
+        lily:additionalInformation "慕われている"@ja ;
+    ] ;
     lily:cast [
         schema:name "直田姫奈"@ja ;
         lily:resource

--- a/RDFs/lily_herensuge.ttl
+++ b/RDFs/lily_herensuge.ttl
@@ -739,11 +739,11 @@
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted true ;
     # lily:boostedSkill ""^^xsd:string ;
-    # lily:charm [
-    #    lily:resource <> ;
-    #    lily:usedIn ""^^xsd:string ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:charm [
+        lily:resource <Mondragon> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     lily:garden "エレンスゲ女学園"^^xsd:string ;
     lily:rank "43"^^xsd:integer ;
     # lily:gardenDepartment ""^^xsd:string ;

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -9021,16 +9021,20 @@
     foaf:age "16"^^xsd:integer ;
     # schema:height ""^^xsd:float ;
     # schema:weight ""^^xsd:float ;
-    # schema:birthDate ""^^xsd:gMonthDay ;
+    schema:birthDate "--02-17"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "A"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     schema:birthPlace "鎌倉府（神奈川県）"@ja, "Kamakura (Kanagawa)"@en ;
-    # lily:favorite ""@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:favorite
+        "地元"@ja,
+        "鷹"@ja ;
+    lily:notGood
+        "目立つこと"@ja,
+        "人前で何かすること"@ja ;
+    lily:hobby_talent "飲食店巡り"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
     lily:rareSkill "レジスタ"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -4491,13 +4491,19 @@
     schema:birthDate "--07-30"^^xsd:gMonthDay ;
     lily:lifeStatus "alive"^^xsd:string ;
     # lily:killedIn ""^^xsd:string ;
-    # lily:bloodType ""^^xsd:string ;
+    lily:bloodType "AB"^^xsd:string ;
     schema:gender "female"^^xsd:string ;
     # lily:color ""^^xsd:hexBinary ;
     # schema:birthPlace ""@ja, ""@en ;
-    lily:favorite "焼きそば"@ja ;
-    # lily:notGood ""@ja ;
-    # lily:hobby_talent ""@ja ;
+    lily:favorite
+        "焼きそば"@ja,
+        "ヒヤシンス"@ja ;
+    lily:notGood
+        "暑さ"@ja,
+        "早起き"@ja ;
+    lily:hobby_talent
+        "星を見ること"@ja,
+        "詩集集め"@ja ;
     lily:skillerVal "98"^^xsd:integer ;
     lily:rareSkill "レジスタ"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -9036,11 +9036,11 @@
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted false ;
     # lily:boostedSkill ""^^xsd:string ;
-    # lily:charm [
-    #    lily:resource <> ;
-    #    lily:usedIn ""^^xsd:string ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:charm [
+        lily:resource <Durandal> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     lily:garden "私立百合ヶ丘女学院"^^xsd:string ;
     lily:gardenDepartment "普通科"^^xsd:string ;
     lily:grade "11"^^xsd:integer ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -6027,6 +6027,25 @@
     a lily:Music ;
 .
 
+<Overcast_Sky>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Overcast Sky"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "新生グラン・エプレ"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "グリーエンターテインメント"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2023-09-28"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT3M46S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Overcast_Sky> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
 <Song_Overcast_Sky>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
@@ -6035,7 +6054,7 @@
     lily:composer "Islet"@ja ;
     lily:arranger "Islet"@ja ;
     lily:additionalInformation "アサルトリリィ Last Bullet メインストーリー 新章グラン・エプレ編のテーマソング"@ja ;
-    schema:duration "PT3M42S"^^xsd:duration ;
+    schema:duration "PT3M46S"^^xsd:duration ;
     lily:singer [
         schema:name "新生グラン・エプレ"@ja ;
         lily:cast [
@@ -6104,6 +6123,25 @@
         ] ;
     ] ;
     a lily:Music ;
+.
+
+<REFLECTIONS>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "REFLECTIONS"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "ヘルヴォル&クエレブレ"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "グリーエンターテインメント"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2023-09-28"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT4M07S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_REFLECTIONS> ;
+    ] ;
+    a lily:MusicAlbum ;
 .
 
 <Song_REFLECTIONS>
@@ -6185,6 +6223,76 @@
     a lily:Music ;
 .
 
+<Song_REFLECTIONS_Cuelebre_Ver>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "REFLECTIONS（クエレブレver.）"@ja ;
+    lily:lyricist "吾龍"@ja ;
+    lily:composer "大和"@ja ;
+    lily:arranger "大和"@ja ;
+    lily:additionalInformation "アサルトリリィ Last Bullet 新章ヘルヴォル編のテーマソング"@ja ;
+    schema:duration "PT4M07S"^^xsd:duration ;
+    lily:singer [
+        schema:name "クエレブレ"@ja ;
+        lily:cast [
+            schema:name "集貝はな"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q74548472>,
+                <https://ja.dbpedia.org/resource/集貝はな> ;
+            lily:performAs <Matsumura_Fuka> ;
+            #lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "河瀬茉希"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q24867153>,
+                <http://ja.dbpedia.org/resource/河瀬茉希> ;
+            lily:performAs <Makino_Mitake> ;
+            #lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "木野日菜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q23948726>,
+                <https://ja.dbpedia.org/resource/木野日菜> ;
+            lily:performAs <Kagawa_Makina> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "指出毬亜"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q28689219>,
+                <https://ja.dbpedia.org/resource/指出毬亜> ;
+            lily:performAs <Morimoto_Yuni> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "直田姫奈"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q64783118>,
+                <http://ja.dbpedia.org/resource/直田姫奈> ;
+            lily:performAs <Kariya_Higure> ;
+        # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Wish_Drop>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Wish Drop"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）＆相澤一葉（CV：藤井彩加）＆飯島恋花（CV：石飛恵里花）＆今叶星（CV：前田佳織里）＆宮川高嶺（CV：礒部花凜）"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "グリーエンターテインメント"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2023-09-28"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT4M29S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Wish_Drop> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
 <Song_Wish_Drop>
     lily:genre "歌"@ja ;
     schema:inLanguage "ja-JP"^^xsd:language ;
@@ -6193,7 +6301,7 @@
     lily:composer "鈴谷皆人"@ja ;
     lily:arranger "鈴谷皆人"@ja ;
     lily:additionalInformation "ラスバレ2.5周年 リリサマ!! テーマ楽曲"@ja ;
-    schema:duration "PT4M27S"^^xsd:duration ;
+    schema:duration "PT4M29S"^^xsd:duration ;
     lily:singer [
         schema:name "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）＆相澤一葉（CV：藤井彩加）＆飯島恋花（CV：石飛恵里花）＆今叶星（CV：前田佳織里）＆宮川高嶺（CV：礒部花凜）"@ja ;
         lily:cast [


### PR DESCRIPTION
### 概要

ラスバレからの情報をもとにデータの更新を行います。

### 情報源

- [早川弥宏のプロフィールを更新](https://github.com/Assault-Lily/LuciaDB/pull/108/commits/62e34568ee238251ee7269a6947ce6ac9ef4b3fb)
- [立原紗癒のプロフィールを更新](https://github.com/Assault-Lily/LuciaDB/pull/108/commits/81b809b3078ea8553b22cb1c4632e4157c7d0b97)
- [苅谷緋紅の情報の追加](https://github.com/Assault-Lily/LuciaDB/pull/108/commits/0645765de7dd8f96377cd94af4431c5ae954f5a0)

ラスバレ内キャラプロフィール（スクリーンショット: https://twitter.com/nagisan_2nd/status/1700716260978540749 ）


- [早川弥宏の使用CHARMを追加](https://github.com/Assault-Lily/LuciaDB/pull/108/commits/3760d05c90c6f2debfbadc70bc92b7175398c465)
- [苅谷緋紅の使用CHARMの追加](https://github.com/Assault-Lily/LuciaDB/pull/108/commits/e2b76dfe84dd222dbb51d0d9dd26ee4df834a3a1)

ラスバレゲーム内お知らせ（アーカイブ: https://allb-news.ulong32.net/4537/ , https://allb-news.ulong32.net/4467/ ）

- [デジタルシングル「Overcast Sky」「REFLECTIONS」「Wish Drop」の追加](https://github.com/Assault-Lily/LuciaDB/pull/108/commits/6f7db576441fdffc04bfd495c3e9d5ef2c7ff995)

アサルトリリィプロジェクト公式サイト（ https://assaultlily-pj.com/news/2023/0927/5 ）


### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

デジタルシングルの追加と同時にREFLECTIONS(クエレブレVer.)の追加も行っています。
ラスバレ内のスクリーンショットをキャラプロフィールのツリーにぶら下げておきました。
