### PR TITLE
ラスバレメインストーリー新章「運命のトリニティ」からの情報追加

### DIFF
--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -376,6 +376,19 @@
     lily:generation "2"^^xsd:decimal ;
     # lily:requiredSkillerVal ""^^xsd:integer ;
     schema:manufacturer <Tsukuyomi_Giken> ;
+    lily:hasVariant <Hi-ThanKiem> ;
+    lily:user <Yoshimura_Thi_Mai> ;
+    a lily:Charm ;
+.
+
+<Hi-ThanKiem>
+    # schema:productID ""^^xsd:string ;
+    lily:seriesName "タンキエム"@ja, "Than Kiem"@en ;
+    schema:name "Hi-タンキエム"@ja, "Hi-Than Kiem"@en ;
+    # lily:generation ""^^xsd:decimal ;
+    # lily:requiredSkillerVal ""^^xsd:integer ;
+    schema:manufacturer <Tsukuyomi_Giken> ;
+    lily:isVariantOf <ThanKiem> ;
     lily:user <Yoshimura_Thi_Mai> ;
     a lily:Charm ;
 .

--- a/RDFs/charm.ttl
+++ b/RDFs/charm.ttl
@@ -303,7 +303,8 @@
         <Kawabata_Hotaru>,
         <Makino_Mitake>,
         <Sejima_Hiromu>,
-        <Izumi_Rosa_Rina> ;
+        <Izumi_Rosa_Rina>,
+        <Tominaga_Shin> ;
     lily:isVariantOf <Tyrfing_Prototype> ;
     schema:isSimilarTo
         <Tyrfing_type_R>,

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -38,7 +38,7 @@
         "身体を動かすこと"@ja,
         "水晶集め"@ja ;
     # lily:skillerVal ""^^xsd:integer ;
-    lily:rareSkill "カリスマ"^^xsd:string ;
+    lily:rareSkill "ラプラス"^^xsd:string ;
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted false ;
     # lily:boostedSkill ""^^xsd:string ;

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -9335,11 +9335,11 @@
     # lily:subSkill ""^^xsd:string ;
     lily:isBoosted false ;
     # lily:boostedSkill ""^^xsd:string ;
-    # lily:charm [
-    #    lily:resource <> ;
-    #    lily:usedIn ""^^xsd:string ;
-    #    lily:additionalInformation ""@ja ;
-    # ] ;
+    lily:charm [
+        lily:resource <Tyrfing_type_T> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        # lily:additionalInformation ""@ja ;
+    ] ;
     lily:garden "私立百合ヶ丘女学院"^^xsd:string ;
     # lily:gardenDepartment ""^^xsd:string ;
     lily:grade "11"^^xsd:integer ;

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -595,6 +595,10 @@
         lily:resource <Gram> ;
         # lily:usedIn ""^^xsd:string ;
         # lily:additionalInformation ""@ja ;
+    ], [
+        lily:resource <Hi-ThanKiem> ;
+        lily:usedIn "ラスバレ"^^xsd:string ;
+        lily:additionalInformation "ユニーク機体"@ja ;
     ] ;
     lily:garden "私立百合ヶ丘女学院"^^xsd:string ;
     lily:gardenDepartment "普通科"^^xsd:string ;

--- a/RDFs/lily_yurigaoka.ttl
+++ b/RDFs/lily_yurigaoka.ttl
@@ -519,7 +519,7 @@
     # lily:pastLegion <> ;
     # lily:taskforce <> ;
     # lily:pastTaskforce <> ;
-    # lily:schutzengel <> ;
+    lily:schutzengel <Yoshimura_Thi_Mai> ;
     # lily:pastSchutzengel <> ;
     # lily:schild <> ;
     # lily:pastSchild <> ;
@@ -615,7 +615,7 @@
     lily:pastTaskforce <Odaiba_Interception_Taskforce_5> ;
     # lily:schutzengel <> ;
     # lily:pastSchutzengel <> ;
-    # lily:schild <> ;
+    lily:schild <Ando_Tazusa> ;
     # lily:pastSchild <> ;
     # lily:roomMate <> ;
     # schema:parent <> ;

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -5968,7 +5968,9 @@
     lily:arranger "神田ジョン"@ja ;
     lily:additionalInformation "アサルトリリィ Last Bullet 2周年テーマ楽曲"@ja ;
     schema:duration "PT3M43S"^^xsd:duration ;
-    schema:inAlbum <Toumei_Diary> ;
+    schema:inAlbum
+        <Toumei_Diary>,
+        <Toumei_Diary_Wish_Drop> ;
     lily:singer [
         schema:name "一柳隊"@ja ;
         lily:cast [
@@ -6024,6 +6026,16 @@
             # lily:additionalInformation ""@ja ;
         ] ;
     ] ;
+    a lily:Music ;
+.
+
+<Song_Toumei_Diary_Instrumental>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    lily:composer "神田ジョン"@ja ;
+    # lily:additionalInformation ""@ja;
+    schema:duration "PT3M43S"^^xsd:duration ;
+    schema:inAlbum <Toumei_Diary_Wish_Drop> ;
     a lily:Music ;
 .
 
@@ -6302,6 +6314,9 @@
     lily:arranger "鈴谷皆人"@ja ;
     lily:additionalInformation "ラスバレ2.5周年 リリサマ!! テーマ楽曲"@ja ;
     schema:duration "PT4M29S"^^xsd:duration ;
+    schema:inAlbum
+        <Wish_Drop>,
+        <Toumei_Diary_Wish_Drop> ;
     lily:singer [
         schema:name "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）＆相澤一葉（CV：藤井彩加）＆飯島恋花（CV：石飛恵里花）＆今叶星（CV：前田佳織里）＆宮川高嶺（CV：礒部花凜）"@ja ;
         lily:cast [
@@ -6345,6 +6360,117 @@
         ] ;
     ] ;
     a lily:Music ;
+.
+
+<Song_Wish_Drop_Last_Bullet_Ver>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Wish Drop(Last Bullet ver.)"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "鈴谷皆人"@ja ;
+    lily:arranger "鈴谷皆人"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M29S"^^xsd:duration ;
+    lily:singer [
+        schema:name "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）＆相澤一葉（CV：藤井彩加）＆今叶星（CV：前田佳織里）"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "藤井彩加"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q28068428>,
+                <https://ja.dbpedia.org/resource/藤井彩加> ;
+            lily:performAs <Aizawa_Kazuha> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "前田佳織里"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q41693141>,
+                <https://ja.dbpedia.org/page/前田佳織里>;
+            lily:performAs <Kon_Kanaho> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Wish_Drop_Riri_Yuyu_Ver>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Wish Drop(梨璃＆夢結ver.)"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "鈴谷皆人"@ja ;
+    lily:arranger "鈴谷皆人"@ja ;
+    # lily:additionalInformation ""@ja ;
+    schema:duration "PT4M29S"^^xsd:duration ;
+    schema:inAlbum <Toumei_Diary_Wish_Drop> ;
+    lily:singer [
+        schema:name "一柳梨璃（CV：赤尾ひかる）＆白井夢結（CV：夏吉ゆうこ）"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.
+
+<Song_Wish_Drop_Instrumental>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    lily:composer "鈴谷皆人"@ja ;
+    # lily:additionalInformation ""@ja;
+    schema:duration "PT4M29S"^^xsd:duration ;
+    schema:inAlbum <Toumei_Diary_Wish_Drop> ;
+    a lily:Music ;
+.
+
+<Toumei_Diary_Wish_Drop>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "トウメイダイアリー/Wish Drop"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "アサルトリリィ Last Bullet"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "グリーエンターテインメント"@ja ;
+    lily:format "アルバム"@ja ;
+    schema:datePublished "2023-11-08"^^xsd:date ;
+    schema:numTracks "6"^^xsd:integer ;
+    schema:timeRequired "PT25M36S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Toumei_Diary> ;
+    ], [
+        lily:listOrder "2"^^xsd:integer ;
+        lily:song <Song_Wish_Drop> ;
+    ], [
+        lily:listOrder "3"^^xsd:integer ;
+        lily:song <Song_Wish_Drop_Last_Bullet_Ver> ;
+    ], [
+        lily:listOrder "4"^^xsd:integer ;
+        lily:song <Song_Wish_Drop_Riri_Yuyu_Ver> ;
+    ], [
+        lily:listOrder "5"^^xsd:integer ;
+        lily:song <Song_Toumei_Diary_Instrumental> ;
+    ], [
+        lily:listOrder "6"^^xsd:integer ;
+        lily:song <Song_Wish_Drop_Instrumental> ;
+    ] ;
+    a lily:MusicAlbum ;
 .
 
 <Adabana>

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -6346,3 +6346,103 @@
     ] ;
     a lily:Music ;
 .
+
+<Adabana>
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Adabana"@ja ;
+    # lily:additionalInformation ""@ja ;
+    # lily:musicProducer ""@ja ;
+    lily:artist "一柳隊 with 早川弥宏・富永真"@ja ;
+    # lily:edition ""@ja ;
+    lily:recordLabel "グリーエンターテインメント"@ja ;
+    lily:format "デジタルシングル"@ja ;
+    schema:datePublished "2023-12-01"^^xsd:date ;
+    schema:numTracks "1"^^xsd:integer ;
+    schema:timeRequired "PT4M09S"^^xsd:duration ;
+    lily:track [
+        lily:listOrder "1"^^xsd:integer ;
+        lily:song <Song_Adabana> ;
+    ] ;
+    a lily:MusicAlbum ;
+.
+
+<Song_Adabana>
+    lily:genre "歌"@ja ;
+    schema:inLanguage "ja-JP"^^xsd:language ;
+    schema:name "Adabana"@ja ;
+    lily:lyricist "安藤紗々"@ja ;
+    lily:composer "神田ジョン"@ja ;
+    lily:arranger "神田ジョン"@ja ;
+    lily:additionalInformation "アサルトリリィ Last Bullet メインストーリー「運命のトリニティ」一柳隊編のテーマ楽曲"@ja ;
+    schema:duration "PT4M09S"^^xsd:duration ;
+    schema:inAlbum <Adabana> ;
+    lily:singer [
+        schema:name "一柳隊 with 早川弥宏・富永真"@ja ;
+        lily:cast [
+            schema:name "赤尾ひかる"@ja ;
+            lily:resource <http://www.wikidata.org/entity/Q28685785> ;
+            lily:performAs <Hitotsuyanagi_Riri> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "夏吉ゆうこ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q66365004> ;
+            lily:performAs <Shirai_Yuyu> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "井澤美香子"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20038660>,
+                <http://ja.dbpedia.org/resource/井澤美香子> ;
+            lily:performAs <Kaede_Johan_Nouvel> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "西本りみ"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q24902567> ;
+            lily:performAs <Futagawa_Fumi> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "紡木吏佐"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q55534197> ;
+            lily:performAs <Ando_Tazusa> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "岩田陽葵"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q16264369>,
+                <http://ja.dbpedia.org/resource/岩田陽葵> ;
+            lily:performAs <Yoshimura_Thi_Mai> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "星守紗凪"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q69635313> ;
+            lily:performAs <Kuo_Shenlin> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "遠野ひかる"@ja ;
+            lily:resource <https://www.wikidata.org/wiki/Q48762060> ;
+            lily:performAs <Wang_Yujia> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "高橋花林"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q20041113>,
+                <http://ja.dbpedia.org/resource/高橋花林> ;
+            lily:performAs <Miliam_Hildegard_von_Guropius> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "大西亜玖璃"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q41693186>,
+                <http://ja.dbpedia.org/resource/大西亜玖璃>;
+            lily:performAs <Hayakawa_Yahiro> ;
+            # lily:additionalInformation ""@ja ;
+        ], [
+            schema:name "小泉萌香"@ja ;
+            lily:resource
+                <https://www.wikidata.org/wiki/Q47472827>,
+                <http://ja.dbpedia.org/resource/小泉萌香>;
+            # lily:additionalInformation ""@ja ;
+        ] ;
+    ] ;
+    a lily:Music ;
+.

--- a/RDFs/media_music.ttl
+++ b/RDFs/media_music.ttl
@@ -6067,6 +6067,7 @@
     lily:arranger "Islet"@ja ;
     lily:additionalInformation "アサルトリリィ Last Bullet メインストーリー 新章グラン・エプレ編のテーマソング"@ja ;
     schema:duration "PT3M46S"^^xsd:duration ;
+    schema:inAlbum <Overcast_Sky> ;
     lily:singer [
         schema:name "新生グラン・エプレ"@ja ;
         lily:cast [
@@ -6165,6 +6166,7 @@
     lily:arranger "大和"@ja ;
     lily:additionalInformation "アサルトリリィ Last Bullet 新章ヘルヴォル編のテーマソング"@ja ;
     schema:duration "PT4M07S"^^xsd:duration ;
+    schema:inAlbum <REFLECTIONS> ;
     lily:singer [
         schema:name "ヘルヴォル&クエレブレ"@ja ;
         lily:cast [


### PR DESCRIPTION
### 概要

標記の情報追加を行います。

### 情報源

ラスバレメインストーリー新章「運命のトリニティ」
情報まとめ→https://twitter.com/nagisan_2nd/status/1733415759022633407

ラスバレゲーム内アナウンス
アーカイブ→https://allb-news.ulong32.net/4838/

CDについてはアサルトリリィプロジェクト公式サイトです
https://assaultlily-pj.com/products/120/https://github.com/Assault-Lily/LuciaDB/commit/2ba2e0d597651929173427b7755fb81ebe923184

### チェック項目

この変更は
- [ ] 新しいクラスやプロパティ定義を追加する
- [ ] 既存のデータ構造やデータ規則の破壊的な変更を含む
- [ ] 既存のRDF制約に違反しており、制約を緩和する必要がある

### 特記事項

梨璃のレアスキルについてですが、ラスバレのストーリー内で普通に使用されているほか、公式の設定資料集（[Boothリンク](https://acus.booth.pm/items/3588686)）にも「ラプラス」との記載がありましたので、変更しました。