### PR TITLE
Fuseki read-onlyイメージ化とビルドジョブ整備（ECS移行 第一段階）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Docker build context is the repository root (see deploy/fuseki/Dockerfile
+# and deploy/fuseki/docker-compose.yaml). Keep the build context small and
+# avoid leaking repo-management files into the image.
+
+.git
+.github
+.rdflint
+rdflint-0.2.1.jar
+rdflint-problems.yml
+CONTRIBUTING.md
+LICENSE
+README.md
+
+# Not loaded into the TDB2 dataset (see deploy/fuseki/Dockerfile comments);
+# these are served separately as static files by the reverse proxy.
+IRIs
+constraints

--- a/.github/workflows/fuseki-build.yml
+++ b/.github/workflows/fuseki-build.yml
@@ -1,0 +1,115 @@
+name: Build and validate Fuseki image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "RDFs/**"
+      - "deploy/fuseki/**"
+      - ".github/workflows/fuseki-build.yml"
+  pull_request:
+    paths:
+      - "RDFs/**"
+      - "deploy/fuseki/**"
+      - ".github/workflows/fuseki-build.yml"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java (for rdflint)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Set up rdflint
+        uses: imas/setup-rdflint@v3
+
+      - name: Run rdflint
+        run: rdflint -config .rdflint/rdflint-config.yml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Fuseki image (bakes TDB2 from RDFs/*.ttl)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/fuseki/Dockerfile
+          build-args: |
+            JENA_VERSION=4.10.0
+          tags: fuseki:${{ github.sha }}
+          load: true
+          push: false
+          # NOTE: Pushing this image to a registry (e.g. ECR) is intentionally
+          # out of scope here. That will be added once the ECS platform
+          # (registry, task definition, service) exists.
+
+      - name: Start container
+        run: |
+          docker run -d --name fuseki-test -p 3030:3030 fuseki:${{ github.sha }}
+
+      - name: Wait for Fuseki to become healthy
+        run: |
+          for i in $(seq 1 60); do
+            status="$(docker inspect --format='{{.State.Health.Status}}' fuseki-test 2>/dev/null || echo unknown)"
+            echo "attempt $i: health=$status"
+            if [ "$status" = "healthy" ]; then
+              exit 0
+            fi
+            if [ "$status" = "unhealthy" ]; then
+              echo "Container reported unhealthy" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+          echo "Timed out waiting for healthy status" >&2
+          exit 1
+
+      - name: Assert read-only behavior
+        run: |
+          set -eu
+
+          expect_status() {
+            method="$1"; url="$2"; expected="$3"; shift 3
+            actual="$(curl -s -o /tmp/resp_body -w '%{http_code}' -X "$method" "$@" "$url")"
+            echo "$method $url -> $actual (expected $expected)"
+            if [ "$actual" != "$expected" ]; then
+              echo "FAIL: $method $url returned $actual, expected $expected" >&2
+              echo "--- response body ---" >&2
+              cat /tmp/resp_body >&2 || true
+              exit 1
+            fi
+          }
+
+          # Query endpoints must work (read-only, always allowed).
+          expect_status GET "http://localhost:3030/sparql?query=ASK%20%7B%7D" 200
+          expect_status GET "http://localhost:3030/sparql/query?query=ASK%20%7B%7D" 200
+
+          # Read-only Graph Store Protocol must work for reads.
+          expect_status GET "http://localhost:3030/sparql/data?default" 200
+
+          # SPARQL Update endpoint must NOT exist.
+          expect_status POST "http://localhost:3030/sparql/update" 404 \
+            --data-urlencode 'update=INSERT DATA { <http://example/s> <http://example/p> "x" }'
+
+          # Graph Store Protocol write must NOT be possible.
+          expect_status POST "http://localhost:3030/sparql/data?default" 404 \
+            -H 'Content-Type: text/turtle' \
+            --data '<http://example/s> <http://example/p> "x" .'
+
+          echo "All read-only assertions passed."
+
+      - name: Dump container logs
+        if: always()
+        run: docker logs fuseki-test || true
+
+      - name: Clean up container
+        if: always()
+        run: docker rm -f fuseki-test || true

--- a/.github/workflows/fuseki-build.yml
+++ b/.github/workflows/fuseki-build.yml
@@ -43,7 +43,7 @@ jobs:
           context: .
           file: deploy/fuseki/Dockerfile
           build-args: |
-            JENA_VERSION=4.10.0
+            JENA_VERSION=6.2.0
           tags: fuseki:${{ github.sha }}
           load: true
           push: false

--- a/.github/workflows/fuseki-build.yml
+++ b/.github/workflows/fuseki-build.yml
@@ -95,12 +95,14 @@ jobs:
           # Read-only Graph Store Protocol must work for reads.
           expect_status GET "http://localhost:3030/sparql/data?default" 200
 
-          # SPARQL Update endpoint must NOT exist.
+          # SPARQL Update endpoint must NOT exist (no fuseki:update service).
           expect_status POST "http://localhost:3030/sparql/update" 404 \
             --data-urlencode 'update=INSERT DATA { <http://example/s> <http://example/p> "x" }'
 
-          # Graph Store Protocol write must NOT be possible.
-          expect_status POST "http://localhost:3030/sparql/data?default" 404 \
+          # Graph Store Protocol write must be rejected. The service exists
+          # (fuseki:gsp-r, read-only) so Fuseki answers 405 Method Not
+          # Allowed rather than 404 Not Found.
+          expect_status POST "http://localhost:3030/sparql/data?default" 405 \
             -H 'Content-Type: text/turtle' \
             --data '<http://example/s> <http://example/p> "x" .'
 

--- a/deploy/fuseki/Dockerfile
+++ b/deploy/fuseki/Dockerfile
@@ -1,0 +1,158 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Apache Jena Fuseki server Dockerfile.
+##
+## This builds a reduced footprint container AND bakes a read-only TDB2
+## database from RDFs/*.ttl at build time. The resulting image is
+## self-contained and immutable: the same image tag always serves the same
+## data, and no data is (re)generated at container start.
+##
+## Build context MUST be the repository root (not this directory), because
+## the RDFs/ directory is copied in relative to the repo root. See
+## deploy/fuseki/docker-compose.yaml for an example.
+
+ARG OPENJDK_VERSION=19
+ARG ALPINE_VERSION=3.15.0
+ARG JENA_VERSION=""
+
+# Internal, passed between stages.
+ARG FUSEKI_DIR=/fuseki
+ARG FUSEKI_JAR=jena-fuseki-server-${JENA_VERSION}.jar
+ARG JAVA_MINIMAL=/opt/java-minimal
+
+## ---- Stage: Download Fuseki and build a reduced-footprint JRE.
+FROM openjdk:${OPENJDK_VERSION}-alpine AS base
+
+ARG JAVA_MINIMAL
+ARG JENA_VERSION
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+ARG REPO=https://repo1.maven.org/maven2
+ARG JAR_URL=${REPO}/org/apache/jena/jena-fuseki-server/${JENA_VERSION}/${FUSEKI_JAR}
+
+RUN [ "${JENA_VERSION}" != "" ] || { echo -e '\n**** Set JENA_VERSION ****\n' ; exit 1 ; }
+RUN echo && echo "==== Docker build for Apache Jena Fuseki ${JENA_VERSION} ====" && echo
+
+# Alpine: For objcopy used in jlink
+RUN apk add --no-cache curl binutils
+
+## -- Fuseki installed and runs in /fuseki.
+WORKDIR $FUSEKI_DIR
+
+## -- Download the jar file.
+COPY deploy/fuseki/download.sh .
+RUN chmod a+x download.sh
+
+# Download, with check of the SHA1 checksum.
+RUN ./download.sh --chksum sha1 "$JAR_URL"
+
+## -- Make reduced Java JDK
+
+ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec"
+RUN \
+  JDEPS="$(jdeps --multi-release base --print-module-deps --ignore-missing-deps ${FUSEKI_JAR})"  && \
+  jlink \
+        --compress 2 --strip-debug --no-header-files --no-man-pages \
+        --output "${JAVA_MINIMAL}" \
+        --add-modules "${JDEPS},${JDEPS_EXTRA}"
+
+ADD deploy/fuseki/entrypoint.sh .
+ADD deploy/fuseki/log4j2.properties .
+ADD deploy/fuseki/config.ttl .
+
+# Run as this user
+# -H : no home directory
+# -D : no password
+RUN adduser -H -D fuseki fuseki
+
+## ---- Stage: bake the TDB2 database from repository RDF data.
+##
+## Uses the same Fuseki jar + minimal JRE built in the "base" stage, so the
+## loader (tdb2.tdbloader) and the server that will later read this database
+## are guaranteed to be the exact same Jena version.
+##
+## Only RDFs/*.ttl (character/legion/media/taskforce instance data) is
+## loaded here. IRIs/ (ontology) and constraints/ (SHACL shapes) are
+## published separately as static files by the reverse proxy in front of
+## Fuseki and are intentionally NOT part of the queryable dataset.
+FROM base AS tdb2build
+
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+ARG JAVA_MINIMAL
+
+ENV JAVA_HOME=${JAVA_MINIMAL}
+ENV JAVA_OPTIONS="-XX:MaxRAM=900M"
+
+WORKDIR $FUSEKI_DIR
+RUN mkdir -p databases staging
+
+COPY RDFs/ ${FUSEKI_DIR}/staging/RDFs/
+
+RUN set -eu; \
+    files="$(find "${FUSEKI_DIR}/staging" -maxdepth 2 -type f \( -name '*.rdf' -o -name '*.ttl' \))"; \
+    [ -n "$files" ] || { echo 'No RDF files found under staging/RDFs' >&2; exit 1; }; \
+    for f in $files; do \
+      echo "Loading $f"; \
+      "$JAVA_HOME/bin/java" $JAVA_OPTIONS -cp "${FUSEKI_DIR}/${FUSEKI_JAR}:/javalibs/*" tdb2.tdbloader --loader=parallel --loc "${FUSEKI_DIR}/databases" "$f"; \
+    done
+
+## ---- Stage: runtime image.
+FROM alpine:${ALPINE_VERSION}
+
+RUN apk add curl
+
+## Import ARGs
+ARG JENA_VERSION
+ARG JAVA_MINIMAL
+ARG FUSEKI_DIR
+ARG FUSEKI_JAR
+
+COPY --from=base /opt/java-minimal /opt/java-minimal
+COPY --from=base /fuseki /fuseki
+COPY --from=base /etc/passwd /etc/passwd
+
+# Pre-built, read-only TDB2 database from the tdb2build stage above.
+COPY --from=tdb2build ${FUSEKI_DIR}/databases ${FUSEKI_DIR}/databases
+
+WORKDIR $FUSEKI_DIR
+
+ARG LOGS=${FUSEKI_DIR}/logs
+
+RUN \
+    mkdir -p $LOGS && \
+    chown -R fuseki ${FUSEKI_DIR} && \
+    chmod a+x entrypoint.sh
+
+## Default environment variables.
+ENV \
+    JAVA_HOME=${JAVA_MINIMAL}           \
+    JAVA_OPTIONS="-XX:MaxRAM=900M"  \
+    JENA_VERSION=${JENA_VERSION}        \
+    FUSEKI_JAR="${FUSEKI_JAR}"          \
+    FUSEKI_DIR="${FUSEKI_DIR}"
+
+USER fuseki
+
+EXPOSE 3030
+
+HEALTHCHECK --start-period=30s --interval=10s --timeout=5s --retries=6 \
+    CMD curl -f "http://localhost:3030/sparql/query?query=ASK%20%7B%7D" || exit 1
+
+ENTRYPOINT ["./entrypoint.sh" ]
+CMD []

--- a/deploy/fuseki/Dockerfile
+++ b/deploy/fuseki/Dockerfile
@@ -26,8 +26,11 @@
 ## the RDFs/ directory is copied in relative to the repo root. See
 ## deploy/fuseki/docker-compose.yaml for an example.
 
-ARG OPENJDK_VERSION=19
-ARG ALPINE_VERSION=3.15.0
+## Base image / Jena version tracking is kept up to date automatically by
+## Renovate (see renovate.json): the eclipse-temurin tag below and the
+## JENA_VERSION build-args in docker-compose.yaml / fuseki-build.yml.
+ARG JAVA_VERSION=21
+ARG ALPINE_VERSION=3.21.2
 ARG JENA_VERSION=""
 
 # Internal, passed between stages.
@@ -36,7 +39,9 @@ ARG FUSEKI_JAR=jena-fuseki-server-${JENA_VERSION}.jar
 ARG JAVA_MINIMAL=/opt/java-minimal
 
 ## ---- Stage: Download Fuseki and build a reduced-footprint JRE.
-FROM openjdk:${OPENJDK_VERSION}-alpine AS base
+## NOTE: upstream jena-fuseki-docker switched from openjdk:*-alpine (removed
+## from Docker Hub) to eclipse-temurin:*-alpine; we follow that here.
+FROM eclipse-temurin:${JAVA_VERSION}-alpine AS base
 
 ARG JAVA_MINIMAL
 ARG JENA_VERSION
@@ -63,22 +68,26 @@ RUN ./download.sh --chksum sha1 "$JAR_URL"
 
 ## -- Make reduced Java JDK
 
-ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec"
+## Provides locale data. Jdeps does not detect it because of SPI, so add it here.
+ARG JDEPS_EXTRA="jdk.crypto.cryptoki,jdk.crypto.ec,jdk.localedata"
+
+## Optional: comma-separated list of locale language tags to keep from
+## jdk.localedata, e.g. "en,ja". We keep "en,ja" since RDF data and error
+## messages are Japanese/English only; leave empty to include all locales.
+ARG JDK_LOCALES="en,ja"
+
 RUN \
   JDEPS="$(jdeps --multi-release base --print-module-deps --ignore-missing-deps ${FUSEKI_JAR})"  && \
+  if [ -n "${JDK_LOCALES}" ] ; then LOCALE_OPT="--include-locales=${JDK_LOCALES}" ; else LOCALE_OPT="" ; fi && \
   jlink \
         --compress 2 --strip-debug --no-header-files --no-man-pages \
         --output "${JAVA_MINIMAL}" \
-        --add-modules "${JDEPS},${JDEPS_EXTRA}"
+        --add-modules "${JDEPS},${JDEPS_EXTRA}" \
+        ${LOCALE_OPT}
 
 ADD deploy/fuseki/entrypoint.sh .
 ADD deploy/fuseki/log4j2.properties .
 ADD deploy/fuseki/config.ttl .
-
-# Run as this user
-# -H : no home directory
-# -D : no password
-RUN adduser -H -D fuseki fuseki
 
 ## ---- Stage: bake the TDB2 database from repository RDF data.
 ##
@@ -115,7 +124,7 @@ RUN set -eu; \
 ## ---- Stage: runtime image.
 FROM alpine:${ALPINE_VERSION}
 
-RUN apk add curl
+RUN apk add --no-cache curl
 
 ## Import ARGs
 ARG JENA_VERSION
@@ -125,7 +134,6 @@ ARG FUSEKI_JAR
 
 COPY --from=base /opt/java-minimal /opt/java-minimal
 COPY --from=base /fuseki /fuseki
-COPY --from=base /etc/passwd /etc/passwd
 
 # Pre-built, read-only TDB2 database from the tdb2build stage above.
 COPY --from=tdb2build ${FUSEKI_DIR}/databases ${FUSEKI_DIR}/databases
@@ -134,9 +142,20 @@ WORKDIR $FUSEKI_DIR
 
 ARG LOGS=${FUSEKI_DIR}/logs
 
+ARG JENA_USER=fuseki
+ARG JENA_GROUP=$JENA_USER
+ARG JENA_GID=1000
+ARG JENA_UID=1000
+
+# Run as this user
+# -H : no home directory
+# -D : no password
+RUN addgroup -g "${JENA_GID}" "${JENA_GROUP}" && \
+    adduser "${JENA_USER}" -G "${JENA_GROUP}" -s /bin/ash -u "${JENA_UID}" -H -D
+
 RUN \
     mkdir -p $LOGS && \
-    chown -R fuseki ${FUSEKI_DIR} && \
+    chown -R "${JENA_USER}" ${FUSEKI_DIR} && \
     chmod a+x entrypoint.sh
 
 ## Default environment variables.
@@ -147,7 +166,7 @@ ENV \
     FUSEKI_JAR="${FUSEKI_JAR}"          \
     FUSEKI_DIR="${FUSEKI_DIR}"
 
-USER fuseki
+USER $JENA_USER
 
 EXPOSE 3030
 

--- a/deploy/fuseki/config.ttl
+++ b/deploy/fuseki/config.ttl
@@ -1,0 +1,46 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+##
+## Fuseki assembler configuration: read-only SPARQL endpoint.
+##
+## This service intentionally defines ONLY query and read-only Graph Store
+## Protocol (GSP) endpoints. SPARQL Update, GSP write, and file-upload
+## endpoints are NOT defined here, so requests to them receive 404/405
+## instead of being served. This is the primary enforcement point for the
+## "read-only" requirement; the reverse proxy in front of this service
+## should also avoid forwarding write-oriented requests as defense in depth.
+
+@prefix fuseki:  <http://jena.apache.org/fuseki#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix tdb2:    <http://jena.apache.org/2016/tdb#> .
+@prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
+
+[] rdf:type fuseki:Server ;
+   fuseki:services ( <#service> ) .
+
+<#service> rdf:type fuseki:Service ;
+    ## Published at http://host:port/sparql
+    fuseki:name "sparql" ;
+
+    ## GET/POST SPARQL query directly at /sparql (matches nginx `location /sparql`).
+    fuseki:endpoint [ fuseki:operation fuseki:query ] ;
+
+    ## GET/POST SPARQL query at /sparql/query (matches README usage and healthcheck).
+    fuseki:endpoint [ fuseki:operation fuseki:query ; fuseki:name "query" ] ;
+
+    ## Read-only Graph Store Protocol at /sparql/data (matches nginx `location /sparql/data`).
+    ## NOTE: fuseki:gsp-r is READ-ONLY GSP. Do not change to fuseki:gsp (which is read-write).
+    fuseki:endpoint [ fuseki:operation fuseki:gsp-r ; fuseki:name "data" ] ;
+
+    ## Intentionally NOT defined:
+    ##   fuseki:endpoint [ fuseki:operation fuseki:update ]   -- SPARQL Update
+    ##   fuseki:endpoint [ fuseki:operation fuseki:gsp ]      -- GSP read-write
+    ##   fuseki:endpoint [ fuseki:operation fuseki:upload ]   -- file upload
+
+    fuseki:dataset <#dataset> .
+
+<#dataset> rdf:type tdb2:DatasetTDB2 ;
+    ## Baked at image build time from RDFs/*.ttl (see Dockerfile). Not rebuilt at
+    ## container startup.
+    tdb2:location "/fuseki/databases" ;
+    tdb2:unionDefaultGraph true .

--- a/deploy/fuseki/config.ttl
+++ b/deploy/fuseki/config.ttl
@@ -16,7 +16,7 @@
 @prefix ja:      <http://jena.hpl.hp.com/2005/11/Assembler#> .
 
 [] rdf:type fuseki:Server ;
-   fuseki:services ( <#service> ) .
+    fuseki:services ( <#service> ) .
 
 <#service> rdf:type fuseki:Service ;
     ## Published at http://host:port/sparql

--- a/deploy/fuseki/docker-compose.yaml
+++ b/deploy/fuseki/docker-compose.yaml
@@ -1,0 +1,25 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+#
+# For local development/testing only. Production deployment target is
+# AWS ECS Fargate (task definition managed separately, not this file).
+#
+# Build context is the repository root because Dockerfile COPYs RDFs/
+# relative to the repo root.
+#
+# Usage (from repository root):
+#   docker compose -f deploy/fuseki/docker-compose.yaml build
+#   docker compose -f deploy/fuseki/docker-compose.yaml up
+
+version: "3.4"
+services:
+  fuseki:
+    build:
+      context: ../../
+      dockerfile: deploy/fuseki/Dockerfile
+      args:
+        JENA_VERSION: "4.10.0"
+    image: fuseki
+    ports:
+      - "3030:3030"
+    volumes:
+      - ./logs:/fuseki/logs:z

--- a/deploy/fuseki/docker-compose.yaml
+++ b/deploy/fuseki/docker-compose.yaml
@@ -17,7 +17,7 @@ services:
       context: ../../
       dockerfile: deploy/fuseki/Dockerfile
       args:
-        JENA_VERSION: "4.10.0"
+        JENA_VERSION: "6.2.0"
     image: fuseki
     ports:
       - "3030:3030"

--- a/deploy/fuseki/download.sh
+++ b/deploy/fuseki/download.sh
@@ -1,0 +1,147 @@
+#!/bin/sh
+
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This is an ash/dash script (it uses "local"), not a bash script.
+# It can run in an Alpine image durign a docker build.
+#
+# The advantage over using docker ADD is that it checks
+# whether download file is already present and does not
+# download each time.
+#
+# Shell script to download URL and check the checksum
+
+USAGE="Usage: $(basename "$0") --chksum [sha1|sha512] URL"
+
+if [ $# -eq 0 ]
+then
+    echo "$USAGE" 2>&1
+    exit 1
+fi
+
+CHKSUM_TYPE='unset'
+
+while [ $# -gt 0 ] ; do
+    case "$1" in
+	--chksum|-chksum|-sha|--sha)
+	    if [ $# -lt 2 ]
+	    then
+		echo "$USAGE" 1>&2
+		exit 1
+	    fi
+	    CHKSUM_TYPE=$2
+	    shift
+	    shift
+	    ;;
+	-h|--help)
+	    echo "$USAGE" 1>&2
+	    exit 0
+	    ;;
+	-*)
+	    echo "$USAGE" 1>&2
+	    exit 1
+	    ;;
+	*)
+	    if [ $# -ne 1 ]
+	    then
+		echo "$USAGE" 1>&2
+		exit 1
+	    fi
+	    URL="$1"
+	    shift
+	    ;;
+    esac
+done
+
+case "${CHKSUM_TYPE}" in
+    unset)
+	echo "$USAGE" 1>&2
+	exit 1
+	;;
+    sha*|md5) ;;
+    *)
+	echo "Bad checksum type: '$CHKSUM_TYPE' (must start 'sha' or be 'md5')" 2>&1
+	exit 1	 
+	;;
+esac
+
+## ---- Script starts ----
+
+ARTIFACT_URL="${URL}"
+ARTIFACT_NAME="$(basename "$ARTIFACT_URL")"
+
+# -------- Checksum details
+
+CHKSUM_EXT=".${CHKSUM_TYPE}"
+CHKSUM_URL="${ARTIFACT_URL}${CHKSUM_EXT}"
+CHKSUM_FILE="${ARTIFACT_NAME}${CHKSUM_EXT}"
+CHKSUMPROG="${CHKSUM_TYPE}sum"
+# --------
+
+CURL_FETCH_OPTS="-s -S --fail --location --max-redirs 3"
+if false
+then
+    echo "ARTIFACT_URL=$ARTIFACT_URL"
+    echo "CHKSUM_URL=$CHKSUM_URL"
+fi
+
+download() { # URL
+    local URL="$1"
+    local FN="$(basename "$URL")"
+    if [ ! -e "$FN" ]
+    then
+	echo "Fetching $URL"
+	curl $CURL_FETCH_OPTS "$URL" --output "$FN" \
+	    || { echo "Bad download of $FN" 2>&1 ; return 1 ; }
+    else
+	echo "$FN already present"
+    fi
+    return 0
+}
+
+checkChksum() { # Filename checksum
+    local FN="$1"
+    local CHKSUM="$2"
+    if [ ! -e "$FN" ]
+    then
+	echo "No such file: '$FN'" 2>&1
+	exit 1
+    fi
+    # NB Two spaces required for busybox
+    echo "$CHKSUM  $FN" | ${CHKSUMPROG} -c > /dev/null
+}
+
+download "$ARTIFACT_URL" || exit 1
+
+if [ -z "$CHKSUM" ]
+then
+    # Checksum not previously set.
+    # Extract from file, copes with variations in content (filename or not)
+    download "$CHKSUM_URL" || exit 1
+    CHKSUM="$(cut -d' ' -f1 "$CHKSUM_FILE")"
+fi
+
+checkChksum "${ARTIFACT_NAME}" "$CHKSUM"
+if [ $? = 0 ]
+then
+    echo "Good download: $ARTIFACT_NAME"
+else
+    echo "BAD download !!!! $ARTIFACT_NAME"
+    echo "To retry: delete downloaded files and try again"
+    exit 1
+fi

--- a/deploy/fuseki/entrypoint.sh
+++ b/deploy/fuseki/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+##
+## The TDB2 database is baked into this image at build time from RDFs/*.ttl
+## (see ../../deploy/fuseki/Dockerfile). Unlike earlier versions of this
+## script, it is NOT rebuilt on every container start: this keeps startup
+## fast and guarantees that the running dataset is an exact, reproducible
+## match for the image tag/digest that was deployed.
+##
+## Whether the service is read-only is controlled entirely by config.ttl,
+## not by command-line flags: no SPARQL Update / GSP-write / upload
+## endpoints are defined there.
+
+exec "$JAVA_HOME/bin/java" $JAVA_OPTIONS -jar "${FUSEKI_DIR}/${FUSEKI_JAR}" --conf "${FUSEKI_DIR}/config.ttl"

--- a/deploy/fuseki/log4j2.properties
+++ b/deploy/fuseki/log4j2.properties
@@ -1,0 +1,70 @@
+## Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+status = error
+name = PropertiesConfig
+
+## filters = threshold
+## filter.threshold.type = ThresholdFilter
+## filter.threshold.level = ALL
+
+appender.console.type = Console
+appender.console.name = OUT
+appender.console.target = SYSTEM_OUT
+appender.console.layout.type = PatternLayout
+## appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-15c{1} :: %m%n
+## Include date.
+appender.console.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+
+## To a file.
+## appender.file.type = File
+## appender.file.name = FILE
+## appender.file.fileName=/fuseki/logs/log.fuseki
+## appender.file.layout.type=PatternLayout
+## appender.file.layout.pattern = [%d{yyyy-MM-dd HH:mm:ss}] %-5p %-15c{1} :: %m%n
+
+rootLogger.level                  = INFO
+rootLogger.appenderRef.stdout.ref = OUT
+
+logger.jena.name  = org.apache.jena
+logger.jena.level = INFO
+
+logger.arq-exec.name  = org.apache.jena.arq.exec
+logger.arq-exec.level = INFO
+
+logger.riot.name  = org.apache.jena.riot
+logger.riot.level = INFO
+
+logger.fuseki.name  = org.apache.jena.fuseki
+logger.fuseki.level = INFO
+
+logger.fuseki-fuseki.name  = org.apache.jena.fuseki.Fuseki
+logger.fuseki-fuseki.level = INFO
+
+logger.fuseki-server.name  = org.apache.jena.fuseki.Server
+logger.fuseki-server.level = INFO
+
+logger.fuseki-admin.name  = org.apache.jena.fuseki.Admin
+logger.fuseki-admin.level = INFO
+
+logger.jetty.name  = org.eclipse.jetty
+logger.jetty.level = WARN
+
+# May be useful to turn up to DEBUG if debugging HTTP communication issues
+logger.apache-http.name   = org.apache.http
+logger.apache-http.level  = WARN
+
+logger.shiro.name = org.apache.shiro
+logger.shiro.level = WARN
+# Hide bug in Shiro 1.5.x
+logger.shiro-realm.name = org.apache.shiro.realm.text.IniRealm
+logger.shiro-realm.level = ERROR
+
+# This goes out in NCSA format
+appender.plain.type = Console
+appender.plain.name = PLAIN
+appender.plain.layout.type = PatternLayout
+appender.plain.layout.pattern = %m%n
+
+logger.request-log.name                   = org.apache.jena.fuseki.Request
+logger.request-log.additivity             = false
+logger.request-log.level                  = OFF
+logger.request-log.appenderRef.plain.ref  = PLAIN

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Keep Fuseki's own release cadence separate from other deps for easier review.",
+      "matchFileNames": ["deploy/fuseki/**"],
+      "groupName": "fuseki image"
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Track the latest org.apache.jena:jena-fuseki-server release used to build the Fuseki image, wherever JENA_VERSION is pinned.",
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^deploy/fuseki/docker-compose\\.yaml$/",
+        "/^\\.github/workflows/fuseki-build\\.yml$/"
+      ],
+      "matchStrings": [
+        "JENA_VERSION:?\\s*[=\"]\\s*(?<currentValue>[0-9.]+)\"?"
+      ],
+      "datasourceTemplate": "maven",
+      "depNameTemplate": "org.apache.jena:jena-fuseki-server",
+      "registryUrlTemplate": "https://repo1.maven.org/maven2"
+    }
+  ]
+}


### PR DESCRIPTION
## 目的
ECS Fargateへの移行に向けた第一段階として、以下を実施:

- Fuseki を read-only（クエリ・GSP read-onlyのみ）で起動する assembler 設定 config.ttl を新設
- TDB2 を GitHub Actions ビルド時に RDFs/*.ttl から生成し、イメージに焼き込む（immutable image方式。従来のようにコンテナ起動毎の再構築は行わない）
- deploy/fuseki/ 配下に、これまでEC2上でのみGit管理外に置かれていたDockerfile等一式を移植
- .github/workflows/fuseki-build.yml を新設し、rdflint・イメージビルド・read-only自動検証（query系200 / update・write系404）をCIで実施

## スコープ外（別タスクで対応）
- ECR等レジストリへのpush
- ECSタスク定義・ALB等の基盤構築

## 動作確認
このPRのCIで fuseki-build ワークフローが通ることをもって検証とする。