### PR TITLE
FusekiのTDB2データセットを正しく読み込む

### DIFF
--- a/.github/workflows/fuseki-build.yml
+++ b/.github/workflows/fuseki-build.yml
@@ -108,6 +108,42 @@ jobs:
             fi
           }
 
+          # The image must contain the RDF dataset, not only a healthy HTTP
+          # server. Keep this assertion above the endpoint checks so an empty
+          # TDB2 database cannot pass CI.
+          triple_count="$(curl -fsS --get \
+            --data-urlencode 'query=SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }' \
+            'http://localhost:3030/sparql/query' \
+            | jq -r '.results.bindings[0].count.value')"
+          echo "triple count: $triple_count"
+          if ! [[ "$triple_count" =~ ^[0-9]+$ ]] || [ "$triple_count" -lt 1 ]; then
+            echo "FAIL: expected a non-empty RDF dataset" >&2
+            exit 1
+          fi
+
+          representative_query='
+            PREFIX schema: <http://schema.org/>
+            PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+            PREFIX lily: <https://luciadb.assaultlily.com/rdf/IRIs/lily_schema.ttl#>
+            SELECT ?name
+            WHERE {
+              ?lily rdf:type lily:Lily;
+                    lily:nameKana ?namekana.
+              FILTER(CONTAINS(?namekana, "あ"))
+              ?lily schema:name ?name.
+              FILTER(lang(?name) = "ja")
+            }
+            LIMIT 1'
+          representative_count="$(curl -fsS --get \
+            --data-urlencode "query=$representative_query" \
+            'http://localhost:3030/sparql/query' \
+            | jq '.results.bindings | length')"
+          echo "representative query rows: $representative_count"
+          if [ "$representative_count" -lt 1 ]; then
+            echo "FAIL: representative Lily query returned no rows" >&2
+            exit 1
+          fi
+
           # Query endpoints must work (read-only, always allowed).
           expect_status GET "http://localhost:3030/sparql?query=ASK%20%7B%7D" 200
           expect_status GET "http://localhost:3030/sparql/query?query=ASK%20%7B%7D" 200

--- a/deploy/fuseki/Dockerfile
+++ b/deploy/fuseki/Dockerfile
@@ -119,7 +119,8 @@ RUN set -eu; \
     for f in $files; do \
       echo "Loading $f"; \
       "$JAVA_HOME/bin/java" $JAVA_OPTIONS -cp "${FUSEKI_DIR}/${FUSEKI_JAR}:/javalibs/*" tdb2.tdbloader --loader=parallel --loc "${FUSEKI_DIR}/databases" "$f"; \
-    done
+    done; \
+    rm -f "${FUSEKI_DIR}/databases/tdb.lock"
 
 ## ---- Stage: runtime image.
 FROM alpine:${ALPINE_VERSION}

--- a/deploy/fuseki/config.ttl
+++ b/deploy/fuseki/config.ttl
@@ -42,5 +42,4 @@
 <#dataset> rdf:type tdb2:DatasetTDB2 ;
     ## Baked at image build time from RDFs/*.ttl (see Dockerfile). Not rebuilt at
     ## container startup.
-    tdb2:location "/fuseki/databases" ;
-    tdb2:unionDefaultGraph true .
+    tdb2:location "/fuseki/databases" .


### PR DESCRIPTION
## 概要

ECSへ移行したFusekiで、イメージ内にTDB2データが存在するにもかかわらずSPARQL検索結果が空になる問題を修正します。

## 原因

Fuseki assembler設定の `tdb2:unionDefaultGraph true` により、事前生成済みTDB2データセットがFusekiから空データセットとして扱われていました。

## 変更内容

- `tdb2:unionDefaultGraph true` を削除
- Dockerイメージにビルド時の古い `tdb.lock` を含めないよう修正
- CIに以下の必須検証を追加
  - トリプル件数が1件以上であること
  - 「あ」を含むLilyのかな名を検索する代表クエリが結果を返すこと
  - 既存のread-only検証を継続

## 検証結果

- 実イメージのTDB2を直接検証: 32,863トリプル
- 修正版Fuseki: 32,863トリプルを取得
- 代表Lilyクエリ: 結果あり
- SPARQL Update: 引き続き拒否

このPRのマージ後、masterのCIでECRイメージを作成し、ECS originへデプロイします。本番DNSの切替はこのPRの対象外です。