### PR TITLE
Fix automatic ECS edge image selection

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -58,7 +58,25 @@ jobs:
         run: |
           set -eu
           echo "fuseki_tag=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          echo "edge_tag=$(git log -1 --format=%H -- deploy/edge IRIs constraints)" >> "$GITHUB_OUTPUT"
+          edge_tag="$(
+            aws ecr describe-images \
+              --repository-name luciadb/edge \
+              --region "$AWS_REGION" \
+              --output json \
+            | jq -r 'sort_by(.imagePushedAt) | reverse | .[].imageTags[]?'
+            | while read -r candidate; do
+                if [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] &&
+                   git merge-base --is-ancestor "$candidate" HEAD; then
+                  printf '%s\n' "$candidate"
+                  break
+                fi
+              done
+          )"
+          if [ -z "$edge_tag" ]; then
+            echo "No ECR edge image found for the release commit." >&2
+            exit 1
+          fi
+          echo "edge_tag=$edge_tag" >> "$GITHUB_OUTPUT"
           echo "last_update=$(TZ=Asia/Tokyo date '+%Y/%m/%d %H:%M:%S')" >> "$GITHUB_OUTPUT"
 
       - name: Verify release images exist


### PR DESCRIPTION
## 概要

ECSデプロイ時に、Fusekiのみ変更されたmerge commitをedgeイメージタグとして誤選択し、ECRに存在しないタグでデプロイが失敗する問題を修正します。

## 変更内容

- ECRのedgeイメージをpush日時の新しい順に確認
- リリースcommitの祖先であり、ECRに実在するedgeイメージを選択
- 対応するイメージがない場合は明示的に失敗

これにより、edge変更を含まないリリースでも直近の有効なedgeイメージを再利用できます。