### PR TITLE
Fix ECS deploy workflow pipeline syntax

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -62,9 +62,9 @@ jobs:
             aws ecr describe-images \
               --repository-name luciadb/edge \
               --region "$AWS_REGION" \
-              --output json \
-            | jq -r 'sort_by(.imagePushedAt) | reverse | .[].imageTags[]?'
-            | while read -r candidate; do
+              --output json |
+            jq -r 'sort_by(.imagePushedAt) | reverse | .[].imageTags[]?' |
+            while read -r candidate; do
                 if [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] &&
                    git merge-base --is-ancestor "$candidate" HEAD; then
                   printf '%s\n' "$candidate"


### PR DESCRIPTION
## 概要

ECSデプロイworkflowのedgeイメージタグ解決処理で、Bashのパイプライン構文エラーが発生していた問題を修正します。

## 原因

`jq` の行末でパイプラインが終了しているにもかかわらず、次行を `| while` で開始していたため、GitHub ActionsのBashが次のエラーで停止していました。

```text
syntax error near unexpected token `|'
```

## 修正内容

パイプ記号を前行末へ移動し、Bashが正しくパイプラインとして解釈できる形に修正しました。

## 影響

タグ解決後のECRイメージ確認、ECSタスク定義登録、サービス更新まで処理が進むようになります。