### PR TITLE
Fix ECS deploy ECR response parsing

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -63,7 +63,7 @@ jobs:
               --repository-name luciadb/edge \
               --region "$AWS_REGION" \
               --output json |
-            jq -r 'sort_by(.imagePushedAt) | reverse | .[].imageTags[]?' |
+            jq -r '.imageDetails | sort_by(.imagePushedAt) | reverse | .[].imageTags[]?' |
             while read -r candidate; do
                 if [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] &&
                    git merge-base --is-ancestor "$candidate" HEAD; then


### PR DESCRIPTION
## 概要

ECSデプロイworkflowのedgeイメージタグ解決処理で、AWS CLIのECRレスポンスを誤って解釈していた問題を修正します。

## 原因

`aws ecr describe-images --output json` の戻り値は配列ではなく、`imageDetails` 配列を含むオブジェクトです。ルートに対して `sort_by(.imagePushedAt)` を実行していたため、次のエラーで停止していました。

```text
jq: Cannot index array with string "imagePushedAt"
```

## 修正内容

`.imageDetails` を取り出してから、push日時順にedgeイメージタグを探索するよう修正しました。