### PR TITLE
Fetch full history for ECS image resolution

### DIFF
--- a/.github/workflows/ecs-deploy.yml
+++ b/.github/workflows/ecs-deploy.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ steps.ref.outputs.value }}
+          fetch-depth: 0
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6


### PR DESCRIPTION
## 概要

ECSデプロイworkflowで、ECRのedgeイメージタグに対応するcommitを検証できず、タグ解決に失敗していた問題を修正します。

## 原因

`git merge-base --is-ancestor` でECRタグのcommit hashを検証していますが、`actions/checkout` の既定設定がshallow clone（深さ1）だったため、過去のedgeイメージcommitがローカルに存在しませんでした。

```text
fatal: Not a valid commit name c6025d5...
No ECR edge image found for the release commit.
```

## 修正内容

`actions/checkout` に `fetch-depth: 0` を設定し、edgeイメージcommitを含む全履歴を取得します。